### PR TITLE
Backports from bsnes-classic

### DIFF
--- a/bsnes/nall/snes/cartridge.hpp
+++ b/bsnes/nall/snes/cartridge.hpp
@@ -14,6 +14,7 @@ public:
   inline unsigned score_header(const uint8_t *data, unsigned size, unsigned addr);
   inline unsigned gameboy_ram_size(const uint8_t *data, unsigned size);
   inline bool gameboy_has_rtc(const uint8_t *data, unsigned size);
+  inline unsigned sufamiturbo_ram_size(const uint8_t *data, unsigned size);
 
   enum HeaderField {
     CartName    = 0x00,
@@ -117,7 +118,11 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
   }
 
   if(type == TypeSufamiTurbo) {
-    xml << "<cartridge/>";
+    xml << "<cartridge>";
+    if(sufamiturbo_ram_size(data, size) > 0) {
+      xml << "  <ram size='" << hex(sufamiturbo_ram_size(data, size)) << "'/>\n";
+    }
+    xml << "</cartridge>\n";
     xmlMemoryMap = xml;
     return;
   }
@@ -356,18 +361,20 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
     xml << "        <map mode='linear' address='a0-bf:8000-ffff'/>\n";
     xml << "      </rom>\n";
     xml << "      <ram>\n";
-    xml << "        <map mode='linear' address='60-63:8000-ffff'/>\n";
-    xml << "        <map mode='linear' address='e0-e3:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='60-63:0000-ffff'/>\n";
+    xml << "        <map mode='linear' address='e0-e3:0000-ffff'/>\n";
     xml << "      </ram>\n";
     xml << "    </slot>\n";
     xml << "    <slot id='B'>\n";
     xml << "      <rom>\n";
+    xml << "        <map mode='linear' address='40-5f:0000-7fff'/>\n";
     xml << "        <map mode='linear' address='40-5f:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='c0-df:0000-7fff'/>\n";
     xml << "        <map mode='linear' address='c0-df:8000-ffff'/>\n";
     xml << "      </rom>\n";
     xml << "      <ram>\n";
-    xml << "        <map mode='linear' address='70-73:8000-ffff'/>\n";
-    xml << "        <map mode='linear' address='f0-f3:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='70-73:0000-ffff'/>\n";
+    xml << "        <map mode='linear' address='f0-f3:0000-ffff'/>\n";
     xml << "      </ram>\n";
     xml << "    </slot>\n";
     xml << "  </sufamiturbo>\n";
@@ -811,10 +818,10 @@ unsigned SNESCartridge::score_header(const uint8_t *data, unsigned size, unsigne
 
 unsigned SNESCartridge::gameboy_ram_size(const uint8_t *data, unsigned size) {
   if(size < 512) return 0;
-  if(data[0x0147] == 0x06) return 512; //MBC2 has 512 nibbles of internal RAM
+  if(data[0x0147] == 0x06) return 512;  //MBC2 has 512 nibbles of internal RAM
   switch(data[0x0149]) {
     case 0x00: return   0 * 1024;
-    case 0x01: return   8 * 1024;
+    case 0x01: return   2 * 1024;
     case 0x02: return   8 * 1024;
     case 0x03: return  32 * 1024;
     case 0x04: return 128 * 1024;
@@ -825,8 +832,13 @@ unsigned SNESCartridge::gameboy_ram_size(const uint8_t *data, unsigned size) {
 
 bool SNESCartridge::gameboy_has_rtc(const uint8_t *data, unsigned size) {
   if(size < 512) return false;
-  if(data[0x0147] == 0x0f ||data[0x0147] == 0x10) return true;
+  if(data[0x0147] == 0x0f || data[0x0147] == 0x10) return true;
   return false;
+}
+
+unsigned SNESCartridge::sufamiturbo_ram_size(const uint8_t *data, unsigned size) {
+  if(size < 0x38) return 0;
+  return data[0x37] * 2048;
 }
 
 }

--- a/bsnes/ruby/audio/alsa.cpp
+++ b/bsnes/ruby/audio/alsa.cpp
@@ -213,7 +213,7 @@ public:
     if(buffer.data) {
       delete[] buffer.data;
       buffer.data = 0;
-	}
+    }
   }
 
   pAudioALSA() {

--- a/bsnes/snes/alt/cpu/cpu.hpp
+++ b/bsnes/snes/alt/cpu/cpu.hpp
@@ -5,15 +5,13 @@ public:
   enum : bool { Threaded = true };
   array<Processor*> coprocessors;
   alwaysinline void step(unsigned clocks);
-  alwaysinline void synchronize_smp();
+  void synchronize_smp();
   void synchronize_ppu();
   void synchronize_coprocessor();
 
   uint8 pio();
   bool joylatch();
   bool interrupt_pending();
-  uint8 port_read(uint8 port);
-  void port_write(uint8 port, uint8 data);
   debugvirtual uint8 mmio_read(unsigned addr);
   debugvirtual void mmio_write(unsigned addr, uint8 data);
 
@@ -69,9 +67,6 @@ private:
   void hdma_run();
   void hdma_init();
   void dma_reset();
-
-  //registers
-  uint8 port_data[4];
 
   struct Channel {
     bool dma_enabled;

--- a/bsnes/snes/alt/cpu/memory.cpp
+++ b/bsnes/snes/alt/cpu/memory.cpp
@@ -12,14 +12,6 @@ bool CPU::interrupt_pending() {
   return false;
 }
 
-uint8 CPU::port_read(uint8 port) {
-  return port_data[port & 3];
-}
-
-void CPU::port_write(uint8 port, uint8 data) {
-  port_data[port & 3] = data;
-}
-
 void CPU::op_io() {
   add_clocks(6);
 }

--- a/bsnes/snes/alt/cpu/mmio.cpp
+++ b/bsnes/snes/alt/cpu/mmio.cpp
@@ -1,11 +1,6 @@
 #ifdef CPU_CPP
 
 uint8 CPU::mmio_read(unsigned addr) {
-  if((addr & 0xffc0) == 0x2140) {
-    synchronize_smp();
-    return smp.port_read(addr & 3);
-  }
-
   switch(addr & 0xffff) {
     case 0x2180: {
       uint8 result = bus.read(0x7e0000 | status.wram_addr);
@@ -98,12 +93,6 @@ uint8 CPU::mmio_read(unsigned addr) {
 }
 
 void CPU::mmio_write(unsigned addr, uint8 data) {
-  if((addr & 0xffc0) == 0x2140) {
-    synchronize_smp();
-    port_write(addr & 3, data);
-    return;
-  }
-
   switch(addr & 0xffff) {
     case 0x2180: {
       bus.write(0x7e0000 | status.wram_addr, data);

--- a/bsnes/snes/alt/cpu/serialization.cpp
+++ b/bsnes/snes/alt/cpu/serialization.cpp
@@ -6,7 +6,6 @@ void CPU::serialize(serializer &s) {
   PPUcounter::serialize(s);
 
   queue.serialize(s);
-  s.array(port_data);
 
   for(unsigned i = 0; i < 8; i++) {
     s.integer(channel[i].dma_enabled);

--- a/bsnes/snes/cartridge/cartridge.cpp
+++ b/bsnes/snes/cartridge/cartridge.cpp
@@ -34,6 +34,8 @@ void Cartridge::load(Mode cartridge_mode, const lstring &xml_list) {
   region = Region::NTSC;
   ram_size = 0;
   spc7110_data_rom_offset = 0x100000;
+  st_A_ram_size = 0;
+  st_B_ram_size = 0;
   supergameboy_version = SuperGameBoyVersion::Version1;
   supergameboy_ram_size = 0;
   supergameboy_rtc_size = 0;
@@ -69,8 +71,8 @@ void Cartridge::load(Mode cartridge_mode, const lstring &xml_list) {
   }
 
   if(mode == Mode::SufamiTurbo) {
-    if(memory::stArom.data()) memory::stAram.map(allocate<uint8_t>(128 * 1024, 0xff), 128 * 1024);
-    if(memory::stBrom.data()) memory::stBram.map(allocate<uint8_t>(128 * 1024, 0xff), 128 * 1024);
+    if(st_A_ram_size) memory::stAram.map(allocate<uint8_t>(st_A_ram_size, 0xff), st_A_ram_size);
+    if(st_B_ram_size) memory::stBram.map(allocate<uint8_t>(st_B_ram_size, 0xff), st_B_ram_size);
   }
 
   if(mode == Mode::SuperGameBoy) {

--- a/bsnes/snes/cartridge/cartridge.hpp
+++ b/bsnes/snes/cartridge/cartridge.hpp
@@ -30,6 +30,8 @@ public:
   readonly<Region> region;
   readonly<unsigned> ram_size;
   readonly<unsigned> spc7110_data_rom_offset;
+  readonly<unsigned> st_A_ram_size;
+  readonly<unsigned> st_B_ram_size;
   readonly<SuperGameBoyVersion> supergameboy_version;
   readonly<unsigned> supergameboy_ram_size;
   readonly<unsigned> supergameboy_rtc_size;

--- a/bsnes/snes/cartridge/cartridge.hpp
+++ b/bsnes/snes/cartridge/cartridge.hpp
@@ -83,6 +83,7 @@ private:
   void parse_xml_sufami_turbo(const char*, bool);
   void parse_xml_gameboy(const char*);
 
+  void xml_parse_memory(xml_element&, Memory&);
   void xml_parse_rom(xml_element&);
   void xml_parse_ram(xml_element&);
   void xml_parse_superfx(xml_element&);

--- a/bsnes/snes/cartridge/xml.cpp
+++ b/bsnes/snes/cartridge/xml.cpp
@@ -100,10 +100,10 @@ void Cartridge::parse_xml_gameboy(const char *data) {
   }
 }
 
-void Cartridge::xml_parse_rom(xml_element &root) {
+void Cartridge::xml_parse_memory(xml_element &root, Memory &memory) {
   foreach(leaf, root.element) {
     if(leaf.name == "map") {
-      Mapping m(memory::cartrom);
+      Mapping m(memory);
       foreach(attr, leaf.attribute) {
         if(attr.name == "address") xml_parse_address(m, attr.content);
         if(attr.name == "mode") xml_parse_mode(m, attr.content);
@@ -115,23 +115,15 @@ void Cartridge::xml_parse_rom(xml_element &root) {
   }
 }
 
+void Cartridge::xml_parse_rom(xml_element &root) {
+  xml_parse_memory(root, memory::cartrom);
+}
+
 void Cartridge::xml_parse_ram(xml_element &root) {
   foreach(attr, root.attribute) {
     if(attr.name == "size") ram_size = hex(attr.content);
   }
-
-  foreach(leaf, root.element) {
-    if(leaf.name == "map") {
-      Mapping m(memory::cartram);
-      foreach(attr, leaf.attribute) {
-        if(attr.name == "address") xml_parse_address(m, attr.content);
-        if(attr.name == "mode") xml_parse_mode(m, attr.content);
-        if(attr.name == "offset") m.offset = hex(attr.content);
-        if(attr.name == "size") m.size = hex(attr.content);
-      }
-      mapping.append(m);
-    }
-  }
+  xml_parse_memory(root, memory::cartram);
 }
 
 void Cartridge::xml_parse_superfx(xml_element &root) {
@@ -139,35 +131,12 @@ void Cartridge::xml_parse_superfx(xml_element &root) {
 
   foreach(node, root.element) {
     if(node.name == "rom") {
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::fxrom);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::fxrom);
     } else if(node.name == "ram") {
       foreach(attr, node.attribute) {
         if(attr.name == "size") ram_size = hex(attr.content);
       }
-
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::fxram);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::fxram);
     } else if(node.name == "mmio") {
       foreach(leaf, node.element) {
         if(leaf.name == "map") {
@@ -187,48 +156,14 @@ void Cartridge::xml_parse_sa1(xml_element &root) {
 
   foreach(node, root.element) {
     if(node.name == "rom") {
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::vsprom);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::vsprom);
     } else if(node.name == "iram") {
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::cpuiram);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::cpuiram);
     } else if(node.name == "bwram") {
       foreach(attr, node.attribute) {
         if(attr.name == "size") ram_size = hex(attr.content);
       }
-
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::cc1bwram);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::cc1bwram);
     } else if(node.name == "mmio") {
       foreach(leaf, node.element) {
         if(leaf.name == "map") {
@@ -339,18 +274,7 @@ void Cartridge::xml_parse_bsx(xml_element &root) {
 
   foreach(node, root.element) {
     if(node.name == "slot") {
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(memory::bsxflash);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, memory::bsxflash);
     } else if(node.name == "mmio") {
       foreach(leaf, node.element) {
         if(leaf.name == "map") {
@@ -378,38 +302,16 @@ void Cartridge::xml_parse_sufamiturbo(xml_element &root) {
         }
       }
 
-      Memory &rom = (slotid == 0 ? memory::stArom : memory::stBrom);
+      Memory &rom = (slotid == 0) ? memory::stArom : memory::stBrom;
       if(rom.size() == -1U) continue;
-      Memory &ram = (slotid == 0 ? memory::stAram : memory::stBram);
-      unsigned ram_size = (slotid == 0 ? st_A_ram_size : st_B_ram_size);
+      Memory &ram = (slotid == 0) ? memory::stAram : memory::stBram;
+      unsigned ram_size = (slotid == 0) ? st_A_ram_size : st_B_ram_size;
 
       foreach(slot, node.element) {
         if(slot.name == "rom") {
-          foreach(leaf, slot.element) {
-            if(leaf.name == "map") {
-              Mapping m(rom);
-              foreach(attr, leaf.attribute) {
-                if(attr.name == "address") xml_parse_address(m, attr.content);
-                if(attr.name == "mode") xml_parse_mode(m, attr.content);
-                if(attr.name == "offset") m.offset = hex(attr.content);
-                if(attr.name == "size") m.size = hex(attr.content);
-              }
-              mapping.append(m);
-            }
-          }
+          xml_parse_memory(slot, rom);
         } else if(slot.name == "ram" && ram_size > 0) {
-          foreach(leaf, slot.element) {
-            if(leaf.name == "map") {
-              Mapping m(ram);
-              foreach(attr, leaf.attribute) {
-                if(attr.name == "address") xml_parse_address(m, attr.content);
-                if(attr.name == "mode") xml_parse_mode(m, attr.content);
-                if(attr.name == "offset") m.offset = hex(attr.content);
-                if(attr.name == "size") m.size = hex(attr.content);
-              }
-              mapping.append(m);
-            }
-          }
+          xml_parse_memory(slot, ram);
         }
       }
     }
@@ -518,19 +420,7 @@ void Cartridge::xml_parse_spc7110(xml_element &root) {
       foreach(attr, node.attribute) {
         if(attr.name == "size") ram_size = hex(attr.content);
       }
-
-      foreach(leaf, node.element) {
-        if(leaf.name == "map") {
-          Mapping m(spc7110ram);
-          foreach(attr, leaf.attribute) {
-            if(attr.name == "address") xml_parse_address(m, attr.content);
-            if(attr.name == "mode") xml_parse_mode(m, attr.content);
-            if(attr.name == "offset") m.offset = hex(attr.content);
-            if(attr.name == "size") m.size = hex(attr.content);
-          }
-          mapping.append(m);
-        }
-      }
+      xml_parse_memory(node, spc7110ram);
     } else if(node.name == "rtc") {
       has_spc7110rtc = true;
 

--- a/bsnes/snes/cpu/cpu.hpp
+++ b/bsnes/snes/cpu/cpu.hpp
@@ -3,12 +3,9 @@ public:
   enum : bool { Threaded = true };
   array<Processor*> coprocessors;
   alwaysinline void step(unsigned clocks);
-  alwaysinline void synchronize_smp();
+  void synchronize_smp();
   void synchronize_ppu();
   void synchronize_coprocessor();
-
-  uint8 port_read(uint2 port) const;
-  void port_write(uint2 port, uint8 data);
 
   uint8 pio();
   bool joylatch();
@@ -72,9 +69,6 @@ private:
     bool hdma_mode;  //0 = init, 1 = run
 
     //MMIO
-    //$2140-217f
-    uint8 port[4];
-
     //$2181-$2183
     uint17 wram_addr;
 

--- a/bsnes/snes/cpu/memory/memory.cpp
+++ b/bsnes/snes/cpu/memory/memory.cpp
@@ -1,8 +1,5 @@
 #ifdef CPU_CPP
 
-uint8 CPU::port_read(uint2 port) const { return status.port[port]; }
-void CPU::port_write(uint2 port, uint8 data) { status.port[port] = data; }
-
 void CPU::op_io() {
   status.clock_count = 6;
   dma_edge();

--- a/bsnes/snes/cpu/mmio/mmio.cpp
+++ b/bsnes/snes/cpu/mmio/mmio.cpp
@@ -355,9 +355,6 @@ void CPU::mmio_power() {
 }
 
 void CPU::mmio_reset() {
-  //$2140-217f
-  foreach(port, status.port) port = 0x00;
-
   //$2181-$2183
   status.wram_addr = 0x000000;
 
@@ -413,12 +410,6 @@ void CPU::mmio_reset() {
 uint8 CPU::mmio_read(unsigned addr) {
   addr &= 0xffff;
 
-  //APU
-  if((addr & 0xffc0) == 0x2140) {  //$2140-$217f
-    synchronize_smp();
-    return smp.port_read(addr);
-  }
-
   //DMA
   if((addr & 0xff80) == 0x4300) {  //$4300-$437f
     unsigned i = (addr >> 4) & 7;
@@ -469,13 +460,6 @@ uint8 CPU::mmio_read(unsigned addr) {
 
 void CPU::mmio_write(unsigned addr, uint8 data) {
   addr &= 0xffff;
-
-  //APU
-  if((addr & 0xffc0) == 0x2140) {  //$2140-$217f
-    synchronize_smp();
-    port_write(addr, data);
-    return;
-  }
 
   //DMA
   if((addr & 0xff80) == 0x4300) {  //$4300-$437f

--- a/bsnes/snes/cpu/serialization.cpp
+++ b/bsnes/snes/cpu/serialization.cpp
@@ -44,8 +44,6 @@ void CPU::serialize(serializer &s) {
   s.integer(status.hdma_pending);
   s.integer(status.hdma_mode);
 
-  s.array(status.port);
-
   s.integer(status.wram_addr);
 
   s.integer(status.joypad_strobe_latch);

--- a/bsnes/snes/smp/mmio/mmio.cpp
+++ b/bsnes/snes/smp/mmio/mmio.cpp
@@ -1,0 +1,13 @@
+#ifdef SMP_CPP
+
+uint8 SMP::mmio_read(unsigned addr) {
+  cpu.synchronize_smp();
+  return port.smp_to_cpu[addr & 3];
+}
+
+void SMP::mmio_write(unsigned addr, uint8 data) {
+  cpu.synchronize_smp();
+  port.cpu_to_smp[addr & 3] = data;
+}
+
+#endif

--- a/bsnes/snes/smp/mmio/mmio.hpp
+++ b/bsnes/snes/smp/mmio/mmio.hpp
@@ -1,0 +1,2 @@
+uint8 mmio_read(unsigned addr);
+void mmio_write(unsigned addr, uint8 data);

--- a/bsnes/snes/smp/serialization.cpp
+++ b/bsnes/snes/smp/serialization.cpp
@@ -19,8 +19,9 @@ void SMP::serialize(serializer &s) {
 
   s.integer(status.dsp_addr);
 
-  s.integer(status.ram0);
-  s.integer(status.ram1);
+  s.array(port.cpu_to_smp);
+  s.array(port.smp_to_cpu);
+  s.array(port.aux);
 
   s.integer(t0.stage0_ticks);
   s.integer(t0.stage1_ticks);

--- a/bsnes/snes/smp/smp.cpp
+++ b/bsnes/snes/smp/smp.cpp
@@ -13,6 +13,7 @@ namespace SNES {
 #include "serialization.cpp"
 #include "iplrom.cpp"
 #include "memory/memory.cpp"
+#include "mmio/mmio.cpp"
 #include "timing/timing.cpp"
 
 void SMP::step(unsigned clocks) {
@@ -93,9 +94,16 @@ void SMP::reset() {
   //$00f2
   status.dsp_addr = 0x00;
 
-  //$00f8,$00f9
-  status.ram0 = 0x00;
-  status.ram1 = 0x00;
+  //$00f4-$00f7
+  for(unsigned i = 0; i < 4; i++) {
+    port.cpu_to_smp[i] = 0;
+    port.smp_to_cpu[i] = 0;
+  }
+
+  //$00f8-$00f9
+  for(unsigned i = 0; i < 2; i++) {
+    port.aux[i] = 0;
+  }
 
   t0.stage0_ticks = 0;
   t1.stage0_ticks = 0;

--- a/bsnes/snes/smp/smp.hpp
+++ b/bsnes/snes/smp/smp.hpp
@@ -1,12 +1,9 @@
-class SMP : public Processor, public SMPcore {
+class SMP : public Processor, public SMPcore, public MMIO {
 public:
   enum : bool { Threaded = true };
   alwaysinline void step(unsigned clocks);
   alwaysinline void synchronize_cpu();
   alwaysinline void synchronize_dsp();
-
-  uint8 port_read(uint2 port) const;
-  void port_write(uint2 port, uint8 data);
 
   void enter();
   void power();
@@ -20,6 +17,7 @@ public:
 
 private:
   #include "memory/memory.hpp"
+  #include "mmio/mmio.hpp"
   #include "timing/timing.hpp"
 
   struct {
@@ -41,11 +39,16 @@ private:
 
     //$00f2
     uint8 dsp_addr;
-
-    //$00f8,$00f9
-    uint8 ram0;
-    uint8 ram1;
   } status;
+
+  struct {
+    //$00f4-$00f7
+    uint8 cpu_to_smp[4];
+    uint8 smp_to_cpu[4];
+
+    //$00f8-$00f9
+    uint8 aux[2];
+  } port;
 
   static void Enter();
   debugvirtual void op_step();

--- a/bsnes/snes/snes.hpp
+++ b/bsnes/snes/snes.hpp
@@ -3,7 +3,7 @@ namespace SNES {
     static const char Name[] = "bsnes-plus";
     static const char Version[] = "073u1";
     static const unsigned SerializerSignature = 0x43545342; //'BSTC'
-    static const unsigned SerializerVersion = 2;
+    static const unsigned SerializerVersion = 3;
   }
 }
 

--- a/bsnes/snes/system/system.cpp
+++ b/bsnes/snes/system/system.cpp
@@ -107,7 +107,7 @@ void System::power() {
 
   bus.power();
   for(unsigned i = 0x2100; i <= 0x213f; i++) memory::mmio.map(i, ppu);
-  for(unsigned i = 0x2140; i <= 0x217f; i++) memory::mmio.map(i, cpu);
+  for(unsigned i = 0x2140; i <= 0x217f; i++) memory::mmio.map(i, smp);
   for(unsigned i = 0x2180; i <= 0x2183; i++) memory::mmio.map(i, cpu);
   for(unsigned i = 0x4016; i <= 0x4017; i++) memory::mmio.map(i, cpu);
   for(unsigned i = 0x4200; i <= 0x421f; i++) memory::mmio.map(i, cpu);

--- a/bsnes/ui-qt/base/filebrowser.cpp
+++ b/bsnes/ui-qt/base/filebrowser.cpp
@@ -147,21 +147,14 @@ void FileBrowser::onChangeCartridge(const string &path) {
   string patch(filepath(nall::basename(filename), config().path.patch), ".ups");
 
   if(file::exists(filename)) {
-    if(striend(filename, ".sfc")) {
-      Cartridge::Information cartinfo;
-      if(cartridge.information(filename, cartinfo)) {
-        info << "<small><table>";
-        info << "<tr><td><b>Title: </b></td><td>" << cartinfo.name << "</td></tr>";
-        info << "<tr><td><b>Region: </b></td><td>" << cartinfo.region << "</td></tr>";
-        info << "<tr><td><b>ROM: </b></td><td>" << cartinfo.romSize * 8 / 1024 / 1024 << "mbit</td></tr>";
-        info << "<tr><td><b>RAM: </b></td><td>";
-        cartinfo.ramSize ? info << cartinfo.ramSize * 8 / 1024 << "kbit</td></tr>" : info << "None</td></tr>";
-        info << "</table></small>";
-      }
-    } else if(striend(filename, ".st")) {
-      unsigned size = file::size(filename);
+    Cartridge::Information cartinfo;
+    if(cartridge.information(filename, cartinfo)) {
       info << "<small><table>";
-      info << "<tr><td><b>ROM: </b></td><td>" << size * 8 / 1024 / 1024 << "mbit</td></tr>";
+      info << "<tr><td><b>Title: </b></td><td>" << cartinfo.name << "</td></tr>";
+      info << "<tr><td><b>Region: </b></td><td>" << cartinfo.region << "</td></tr>";
+      info << "<tr><td><b>ROM: </b></td><td>" << cartinfo.romSize * 8 / 1024 / 1024 << "mbit</td></tr>";
+      info << "<tr><td><b>RAM: </b></td><td>";
+      cartinfo.ramSize ? info << cartinfo.ramSize * 8 / 1024 << "kbit</td></tr>" : info << "None</td></tr>";
       info << "</table></small>";
     }
   }

--- a/supergameboy/nall/snes/cartridge.hpp
+++ b/supergameboy/nall/snes/cartridge.hpp
@@ -14,6 +14,7 @@ public:
   inline unsigned score_header(const uint8_t *data, unsigned size, unsigned addr);
   inline unsigned gameboy_ram_size(const uint8_t *data, unsigned size);
   inline bool gameboy_has_rtc(const uint8_t *data, unsigned size);
+  inline unsigned sufamiturbo_ram_size(const uint8_t *data, unsigned size);
 
   enum HeaderField {
     CartName    = 0x00,
@@ -117,7 +118,11 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
   }
 
   if(type == TypeSufamiTurbo) {
-    xml << "<cartridge/>";
+    xml << "<cartridge>";
+    if(sufamiturbo_ram_size(data, size) > 0) {
+      xml << "  <ram size='" << hex(sufamiturbo_ram_size(data, size)) << "'/>\n";
+    }
+    xml << "</cartridge>\n";
     xmlMemoryMap = xml;
     return;
   }
@@ -356,18 +361,20 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
     xml << "        <map mode='linear' address='a0-bf:8000-ffff'/>\n";
     xml << "      </rom>\n";
     xml << "      <ram>\n";
-    xml << "        <map mode='linear' address='60-63:8000-ffff'/>\n";
-    xml << "        <map mode='linear' address='e0-e3:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='60-63:0000-ffff'/>\n";
+    xml << "        <map mode='linear' address='e0-e3:0000-ffff'/>\n";
     xml << "      </ram>\n";
     xml << "    </slot>\n";
     xml << "    <slot id='B'>\n";
     xml << "      <rom>\n";
+    xml << "        <map mode='linear' address='40-5f:0000-7fff'/>\n";
     xml << "        <map mode='linear' address='40-5f:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='c0-df:0000-7fff'/>\n";
     xml << "        <map mode='linear' address='c0-df:8000-ffff'/>\n";
     xml << "      </rom>\n";
     xml << "      <ram>\n";
-    xml << "        <map mode='linear' address='70-73:8000-ffff'/>\n";
-    xml << "        <map mode='linear' address='f0-f3:8000-ffff'/>\n";
+    xml << "        <map mode='linear' address='70-73:0000-ffff'/>\n";
+    xml << "        <map mode='linear' address='f0-f3:0000-ffff'/>\n";
     xml << "      </ram>\n";
     xml << "    </slot>\n";
     xml << "  </sufamiturbo>\n";
@@ -811,10 +818,10 @@ unsigned SNESCartridge::score_header(const uint8_t *data, unsigned size, unsigne
 
 unsigned SNESCartridge::gameboy_ram_size(const uint8_t *data, unsigned size) {
   if(size < 512) return 0;
-  if(data[0x0147] == 0x06) return 512; //MBC2 has 512 nibbles of internal RAM
+  if(data[0x0147] == 0x06) return 512;  //MBC2 has 512 nibbles of internal RAM
   switch(data[0x0149]) {
     case 0x00: return   0 * 1024;
-    case 0x01: return   8 * 1024;
+    case 0x01: return   2 * 1024;
     case 0x02: return   8 * 1024;
     case 0x03: return  32 * 1024;
     case 0x04: return 128 * 1024;
@@ -825,8 +832,13 @@ unsigned SNESCartridge::gameboy_ram_size(const uint8_t *data, unsigned size) {
 
 bool SNESCartridge::gameboy_has_rtc(const uint8_t *data, unsigned size) {
   if(size < 512) return false;
-  if(data[0x0147] == 0x0f ||data[0x0147] == 0x10) return true;
+  if(data[0x0147] == 0x0f || data[0x0147] == 0x10) return true;
   return false;
+}
+
+unsigned SNESCartridge::sufamiturbo_ram_size(const uint8_t *data, unsigned size) {
+  if(size < 0x38) return 0;
+  return data[0x37] * 2048;
 }
 
 }


### PR DESCRIPTION
Backports changes from the bsnes-classic SVN repo: revisions 33 through 38, with the exception of r34 and r37 (already done in another way in bsnes-plus). r83 needed some minor tweaks to apply.