### PR TITLE
Fix build with mingw-w64.

### DIFF
--- a/bsnes/ruby/input/rawinput.cpp
+++ b/bsnes/ruby/input/rawinput.cpp
@@ -291,12 +291,12 @@ public:
     wc.hIcon = LoadIcon(0, IDI_APPLICATION);
     wc.hInstance = GetModuleHandle(0);
     wc.lpfnWndProc = RawInputWindowProc;
-    wc.lpszClassName = (LPCSTR)"RawInputClass";
+    wc.lpszClassName = (LPCTSTR)"RawInputClass";
     wc.lpszMenuName = 0;
     wc.style = CS_VREDRAW | CS_HREDRAW;
     RegisterClass(&wc);
 
-    hwnd = CreateWindow((LPCSTR)"RawInputClass", (LPCSTR)"RawInputClass", WS_POPUP,
+    hwnd = CreateWindow((LPCTSTR)"RawInputClass", (LPCTSTR)"RawInputClass", WS_POPUP,
       0, 0, 64, 64, 0, 0, GetModuleHandle(0), 0);
 
     //enumerate all HID devices


### PR DESCRIPTION
mingw-w64 4.9.2 is setup to be unicode-aware by default, thus expecting wchars in most places. String literals in rawinput were cast as LPCSTR, while mingw-w64 expected LPCWSTR, which broke build. This commit fixes build with that toolchain, while keeping compatibility with non-unicode toolchains. Tested with mingw-w64 i686-4.9.2-posix-dwarf-rt_v4-rev2.