### PR TITLE
Debugger: fix duplicate DMA read

### DIFF
--- a/bsnes/snes/cpu/debugger/debugger.cpp
+++ b/bsnes/snes/cpu/debugger/debugger.cpp
@@ -75,9 +75,9 @@ uint8 CPUDebugger::dma_read(uint32 abus) {
   int offset = cartridge.rom_offset(abus);
   if (offset >= 0) cart_usage[offset] |= UsageRead;
   
-  uint8 data = bus.read(abus);
+  uint8 data = CPU::dma_read(abus);
   debugger.breakpoint_test(Debugger::Breakpoint::Source::CPUBus, Debugger::Breakpoint::Mode::Read, abus, data);
-  return CPU::dma_read(abus);
+  return data;
 }
 
 void CPUDebugger::op_write(uint32 addr, uint8 data) {


### PR DESCRIPTION
Stumbled upon this when trying to spot a bug in my MSU1 video player.

DMA source is read twice in CPUDebugger::dma_read which breaks sources
that change state on read (e.g. MSU1 data). Read only once before
checking breakpoints and return the buffered result.