### PR TITLE
Backport most recent MSU1 behaviour

### DIFF
--- a/bsnes/snes/alt/dsp/SPC_DSP.h
+++ b/bsnes/snes/alt/dsp/SPC_DSP.h
@@ -231,6 +231,9 @@ private:
 	void echo_30();
 	
 	void soft_reset_common();
+
+public:
+	bool mute() { return m.regs[r_flg] & 0x40; }
 };
 
 #include <assert.h>

--- a/bsnes/snes/alt/dsp/dsp.cpp
+++ b/bsnes/snes/alt/dsp/dsp.cpp
@@ -31,6 +31,10 @@ void DSP::enter() {
   }
 }
 
+bool DSP::mute() {
+  return spc_dsp.mute();
+}
+
 uint8 DSP::read(uint8 addr) {
   return spc_dsp.read(addr);
 }

--- a/bsnes/snes/alt/dsp/dsp.hpp
+++ b/bsnes/snes/alt/dsp/dsp.hpp
@@ -6,6 +6,7 @@ public:
   alwaysinline void step(unsigned clocks);
   alwaysinline void synchronize_smp();
 
+  bool mute();
   uint8 read(uint8 addr);
   void write(uint8 addr, uint8 data);
 

--- a/bsnes/snes/chip/msu1/msu1.cpp
+++ b/bsnes/snes/chip/msu1/msu1.cpp
@@ -10,6 +10,11 @@ MSU1 msu1;
 void MSU1::Enter() { msu1.enter(); }
 
 void MSU1::enter() {
+  if(boot == true) {
+    boot = false;
+    for(unsigned addr = 0x2000; addr <= 0x2007; addr++) mmio_write(addr, 0x00);
+  }
+
   while(true) {
     if(scheduler.sync == Scheduler::SynchronizeMode::All) {
       scheduler.exit(Scheduler::ExitReason::SynchronizeEvent);
@@ -36,8 +41,11 @@ void MSU1::enter() {
       }
     }
 
-    left  = sclamp<16>((double)left  * (double)mmio.audio_volume / 255.0);
-    right = sclamp<16>((double)right * (double)mmio.audio_volume / 255.0);
+    signed lchannel = (double)left  * (double)mmio.audio_volume / 255.0;
+    signed rchannel = (double)right * (double)mmio.audio_volume / 255.0;
+    left  = sclamp<16>(lchannel);
+    right = sclamp<16>(rchannel);
+    if(dsp.mute()) left = 0, right = 0;
 
     audio.coprocessor_sample(left, right);
     step(1);
@@ -62,6 +70,7 @@ void MSU1::power() {
 
 void MSU1::reset() {
   create(MSU1::Enter, 44100);
+  boot = true;
 
   mmio.data_offset  = 0;
   mmio.audio_offset = 0;
@@ -71,6 +80,7 @@ void MSU1::reset() {
   mmio.audio_busy   = true;
   mmio.audio_repeat = false;
   mmio.audio_play   = false;
+  mmio.audio_error  = false;
 }
 
 uint8 MSU1::mmio_read(unsigned addr) {
@@ -81,6 +91,7 @@ uint8 MSU1::mmio_read(unsigned addr) {
          | (mmio.audio_busy   << 6)
          | (mmio.audio_repeat << 5)
          | (mmio.audio_play   << 4)
+         | (mmio.audio_error  << 3)
          | (Revision          << 0);
   }
 
@@ -141,6 +152,7 @@ void MSU1::mmio_write(unsigned addr, uint8 data) {
     mmio.audio_busy   = false;
     mmio.audio_repeat = false;
     mmio.audio_play   = false;
+    mmio.audio_error  = !audiofile.open();
   }
 
   if(addr == 0x2006) {

--- a/bsnes/snes/chip/msu1/msu1.hpp
+++ b/bsnes/snes/chip/msu1/msu1.hpp
@@ -13,6 +13,7 @@ public:
   void serialize(serializer&);
 
 private:
+  bool boot;
   file datafile;
   file audiofile;
 
@@ -21,6 +22,7 @@ private:
     AudioBusy      = 0x40,
     AudioRepeating = 0x20,
     AudioPlaying   = 0x10,
+    AudioError     = 0x08,
     Revision       = 0x01,
   };
 
@@ -36,6 +38,7 @@ private:
     bool audio_busy;
     bool audio_repeat;
     bool audio_play;
+    bool audio_error;
   } mmio;
 };
 

--- a/bsnes/snes/chip/msu1/serialization.cpp
+++ b/bsnes/snes/chip/msu1/serialization.cpp
@@ -14,6 +14,7 @@ void MSU1::serialize(serializer &s) {
   s.integer(mmio.audio_busy);
   s.integer(mmio.audio_repeat);
   s.integer(mmio.audio_play);
+  s.integer(mmio.audio_error);
 
   if(datafile.open()) datafile.close();
   if(datafile.open(string(cartridge.basename(), ".msu"), file::mode::read)) {

--- a/bsnes/snes/dsp/dsp.cpp
+++ b/bsnes/snes/dsp/dsp.cpp
@@ -205,6 +205,10 @@ void DSP::tick() {
 
 /* register interface for S-SMP $00f2,$00f3 */
 
+bool DSP::mute() {
+  return state.regs[r_flg] & 0x40;
+}
+
 uint8 DSP::read(uint8 addr) {
   return state.regs[addr];
 }

--- a/bsnes/snes/dsp/dsp.hpp
+++ b/bsnes/snes/dsp/dsp.hpp
@@ -4,6 +4,7 @@ public:
   alwaysinline void step(unsigned clocks);
   alwaysinline void synchronize_smp();
 
+  bool mute();
   uint8 read(uint8 addr);
   void write(uint8 addr, uint8 data);
 


### PR DESCRIPTION
Is it ok to post backports to this repo? :)

v073 has some shortcomings in MSU1 behaviour, most notably it ignores
the DSP mute flag (which will cut off external audio on a real SNES).
Hack authors stumble upon those when running on real hardware for the
first time after testing on less recent bsnes versions.

Backports from higan v094:
- audio error flag
- init behaviour (zero out MSU1 regs)
- initial volume
- DSP mute flag