### PR TITLE
Backport bps support

### DIFF
--- a/bsnes/nall/bps/delta.hpp
+++ b/bsnes/nall/bps/delta.hpp
@@ -1,0 +1,214 @@
+#ifndef NALL_BPS_DELTA_HPP
+#define NALL_BPS_DELTA_HPP
+
+#include <nall/crc32.hpp>
+#include <nall/file.hpp>
+#include <nall/filemap.hpp>
+#include <nall/stdint.hpp>
+#include <nall/string.hpp>
+
+namespace nall {
+
+struct bpsdelta {
+  inline void source(const uint8_t *data, unsigned size);
+  inline void target(const uint8_t *data, unsigned size);
+
+  inline bool source(const string &filename);
+  inline bool target(const string &filename);
+  inline bool create(const string &filename, const string &metadata = "");
+
+protected:
+  enum : unsigned { SourceRead, TargetRead, SourceCopy, TargetCopy };
+  enum : unsigned { Granularity = 1 };
+
+  struct Node {
+    unsigned offset;
+    Node *next;
+    inline Node() : offset(0), next(0) {}
+    inline ~Node() { if(next) delete next; }
+  };
+
+  filemap sourceFile;
+  const uint8_t *sourceData;
+  unsigned sourceSize;
+
+  filemap targetFile;
+  const uint8_t *targetData;
+  unsigned targetSize;
+};
+
+void bpsdelta::source(const uint8_t *data, unsigned size) {
+  sourceData = data;
+  sourceSize = size;
+}
+
+void bpsdelta::target(const uint8_t *data, unsigned size) {
+  targetData = data;
+  targetSize = size;
+}
+
+bool bpsdelta::source(const string &filename) {
+  if(sourceFile.open(filename, filemap::mode::read) == false) return false;
+  source(sourceFile.data(), sourceFile.size());
+  return true;
+}
+
+bool bpsdelta::target(const string &filename) {
+  if(targetFile.open(filename, filemap::mode::read) == false) return false;
+  target(targetFile.data(), targetFile.size());
+  return true;
+}
+
+bool bpsdelta::create(const string &filename, const string &metadata) {
+  file modifyFile;
+  if(modifyFile.open(filename, file::mode::write) == false) return false;
+
+  uint32_t sourceChecksum = ~0, modifyChecksum = ~0;
+  unsigned sourceRelativeOffset = 0, targetRelativeOffset = 0, outputOffset = 0;
+
+  auto write = [&](uint8_t data) {
+    modifyFile.write(data);
+    modifyChecksum = crc32_adjust(modifyChecksum, data);
+  };
+
+  auto encode = [&](uint64_t data) {
+    while(true) {
+      uint64_t x = data & 0x7f;
+      data >>= 7;
+      if(data == 0) {
+        write(0x80 | x);
+        break;
+      }
+      write(x);
+      data--;
+    }
+  };
+
+  write('B');
+  write('P');
+  write('S');
+  write('1');
+
+  encode(sourceSize);
+  encode(targetSize);
+
+  unsigned markupSize = metadata.length();
+  encode(markupSize);
+  for(unsigned n = 0; n < markupSize; n++) write(metadata[n]);
+
+  Node *sourceTree[65536], *targetTree[65536];
+  for(unsigned n = 0; n < 65536; n++) sourceTree[n] = 0, targetTree[n] = 0;
+
+  //source tree creation
+  for(unsigned offset = 0; offset < sourceSize; offset++) {
+    uint16_t symbol = sourceData[offset + 0];
+    sourceChecksum = crc32_adjust(sourceChecksum, symbol);
+    if(offset < sourceSize - 1) symbol |= sourceData[offset + 1] << 8;
+    Node *node = new Node;
+    node->offset = offset;
+    node->next = sourceTree[symbol];
+    sourceTree[symbol] = node;
+  }
+
+  unsigned targetReadLength = 0;
+
+  auto targetReadFlush = [&]() {
+    if(targetReadLength) {
+      encode(TargetRead | ((targetReadLength - 1) << 2));
+      unsigned offset = outputOffset - targetReadLength;
+      while(targetReadLength) write(targetData[offset++]), targetReadLength--;
+    }
+  };
+
+  while(outputOffset < targetSize) {
+    unsigned maxLength = 0, maxOffset = 0, mode = TargetRead;
+
+    uint16_t symbol = targetData[outputOffset + 0];
+    if(outputOffset < targetSize - 1) symbol |= targetData[outputOffset + 1] << 8;
+
+    { //source read
+      unsigned length = 0, offset = outputOffset;
+      while(offset < sourceSize && offset < targetSize && sourceData[offset] == targetData[offset]) {
+        length++;
+        offset++;
+      }
+      if(length > maxLength) maxLength = length, mode = SourceRead;
+    }
+
+    { //source copy
+      Node *node = sourceTree[symbol];
+      while(node) {
+        unsigned length = 0, x = node->offset, y = outputOffset;
+        while(x < sourceSize && y < targetSize && sourceData[x++] == targetData[y++]) length++;
+        if(length > maxLength) maxLength = length, maxOffset = node->offset, mode = SourceCopy;
+        node = node->next;
+      }
+    }
+
+    { //target copy
+      Node *node = targetTree[symbol];
+      while(node) {
+        unsigned length = 0, x = node->offset, y = outputOffset;
+        while(y < targetSize && targetData[x++] == targetData[y++]) length++;
+        if(length > maxLength) maxLength = length, maxOffset = node->offset, mode = TargetCopy;
+        node = node->next;
+      }
+
+      //target tree append
+      node = new Node;
+      node->offset = outputOffset;
+      node->next = targetTree[symbol];
+      targetTree[symbol] = node;
+    }
+
+    { //target read
+      if(maxLength < 4) {
+        maxLength = min((unsigned)Granularity, targetSize - outputOffset);
+        mode = TargetRead;
+      }
+    }
+
+    if(mode != TargetRead) targetReadFlush();
+
+    switch(mode) {
+    case SourceRead:
+      encode(SourceRead | ((maxLength - 1) << 2));
+      break;
+    case TargetRead:
+      //delay write to group sequential TargetRead commands into one
+      targetReadLength += maxLength;
+      break;
+    case SourceCopy:
+    case TargetCopy:
+      encode(mode | ((maxLength - 1) << 2));
+      signed relativeOffset;
+      if(mode == SourceCopy) {
+        relativeOffset = maxOffset - sourceRelativeOffset;
+        sourceRelativeOffset = maxOffset + maxLength;
+      } else {
+        relativeOffset = maxOffset - targetRelativeOffset;
+        targetRelativeOffset = maxOffset + maxLength;
+      }
+      encode((relativeOffset < 0) | (abs(relativeOffset) << 1));
+      break;
+    }
+
+    outputOffset += maxLength;
+  }
+
+  targetReadFlush();
+
+  sourceChecksum = ~sourceChecksum;
+  for(unsigned n = 0; n < 32; n += 8) write(sourceChecksum >> n);
+  uint32_t targetChecksum = crc32_calculate(targetData, targetSize);
+  for(unsigned n = 0; n < 32; n += 8) write(targetChecksum >> n);
+  uint32_t outputChecksum = ~modifyChecksum;
+  for(unsigned n = 0; n < 32; n += 8) write(outputChecksum >> n);
+
+  modifyFile.close();
+  return true;
+}
+
+}
+
+#endif

--- a/bsnes/nall/bps/linear.hpp
+++ b/bsnes/nall/bps/linear.hpp
@@ -1,0 +1,152 @@
+#ifndef NALL_BPS_LINEAR_HPP
+#define NALL_BPS_LINEAR_HPP
+
+#include <nall/crc32.hpp>
+#include <nall/file.hpp>
+#include <nall/filemap.hpp>
+#include <nall/stdint.hpp>
+#include <nall/string.hpp>
+
+namespace nall {
+
+struct bpslinear {
+  inline void source(const uint8_t *data, unsigned size);
+  inline void target(const uint8_t *data, unsigned size);
+
+  inline bool source(const string &filename);
+  inline bool target(const string &filename);
+  inline bool create(const string &filename, const string &metadata = "");
+
+protected:
+  enum : unsigned { SourceRead, TargetRead, SourceCopy, TargetCopy };
+  enum : unsigned { Granularity = 1 };
+
+  filemap sourceFile;
+  const uint8_t *sourceData;
+  unsigned sourceSize;
+
+  filemap targetFile;
+  const uint8_t *targetData;
+  unsigned targetSize;
+};
+
+void bpslinear::source(const uint8_t *data, unsigned size) {
+  sourceData = data;
+  sourceSize = size;
+}
+
+void bpslinear::target(const uint8_t *data, unsigned size) {
+  targetData = data;
+  targetSize = size;
+}
+
+bool bpslinear::source(const string &filename) {
+  if(sourceFile.open(filename, filemap::mode::read) == false) return false;
+  source(sourceFile.data(), sourceFile.size());
+  return true;
+}
+
+bool bpslinear::target(const string &filename) {
+  if(targetFile.open(filename, filemap::mode::read) == false) return false;
+  target(targetFile.data(), targetFile.size());
+  return true;
+}
+
+bool bpslinear::create(const string &filename, const string &metadata) {
+  file modifyFile;
+  if(modifyFile.open(filename, file::mode::write) == false) return false;
+
+  uint32_t modifyChecksum = ~0;
+  unsigned targetRelativeOffset = 0, outputOffset = 0;
+
+  auto write = [&](uint8_t data) {
+    modifyFile.write(data);
+    modifyChecksum = crc32_adjust(modifyChecksum, data);
+  };
+
+  auto encode = [&](uint64_t data) {
+    while(true) {
+      uint64_t x = data & 0x7f;
+      data >>= 7;
+      if(data == 0) {
+        write(0x80 | x);
+        break;
+      }
+      write(x);
+      data--;
+    }
+  };
+
+  unsigned targetReadLength = 0;
+
+  auto targetReadFlush = [&]() {
+    if(targetReadLength) {
+      encode(TargetRead | ((targetReadLength - 1) << 2));
+      unsigned offset = outputOffset - targetReadLength;
+      while(targetReadLength) write(targetData[offset++]), targetReadLength--;
+    }
+  };
+
+  write('B');
+  write('P');
+  write('S');
+  write('1');
+
+  encode(sourceSize);
+  encode(targetSize);
+
+  unsigned markupSize = metadata.length();
+  encode(markupSize);
+  for(unsigned n = 0; n < markupSize; n++) write(metadata[n]);
+
+  while(outputOffset < targetSize) {
+    unsigned sourceLength = 0;
+    for(unsigned n = 0; outputOffset + n < min(sourceSize, targetSize); n++) {
+      if(sourceData[outputOffset + n] != targetData[outputOffset + n]) break;
+      sourceLength++;
+    }
+
+    unsigned rleLength = 0;
+    for(unsigned n = 1; outputOffset + n < targetSize; n++) {
+      if(targetData[outputOffset] != targetData[outputOffset + n]) break;
+      rleLength++;
+    }
+
+    if(rleLength >= 4) {
+      //write byte to repeat
+      targetReadLength++;
+      outputOffset++;
+      targetReadFlush();
+
+      //copy starting from repetition byte
+      encode(TargetCopy | ((rleLength - 1) << 2));
+      unsigned relativeOffset = (outputOffset - 1) - targetRelativeOffset;
+      encode(relativeOffset << 1);
+      outputOffset += rleLength;
+      targetRelativeOffset = outputOffset - 1;
+    } else if(sourceLength >= 4) {
+      targetReadFlush();
+      encode(SourceRead | ((sourceLength - 1) << 2));
+      outputOffset += sourceLength;
+    } else {
+      targetReadLength += Granularity;
+      outputOffset += Granularity;
+    }
+  }
+
+  targetReadFlush();
+
+  uint32_t sourceChecksum = crc32_calculate(sourceData, sourceSize);
+  for(unsigned n = 0; n < 32; n += 8) write(sourceChecksum >> n);
+  uint32_t targetChecksum = crc32_calculate(targetData, targetSize);
+  for(unsigned n = 0; n < 32; n += 8) write(targetChecksum >> n);
+  uint32_t outputChecksum = ~modifyChecksum;
+  for(unsigned n = 0; n < 32; n += 8) write(outputChecksum >> n);
+
+  modifyFile.close();
+  return true;
+}
+
+}
+
+#endif

--- a/bsnes/nall/bps/metadata.hpp
+++ b/bsnes/nall/bps/metadata.hpp
@@ -1,0 +1,121 @@
+#ifndef NALL_BPS_METADATA_HPP
+#define NALL_BPS_METADATA_HPP
+
+#include <nall/crc32.hpp>
+#include <nall/file.hpp>
+#include <nall/filemap.hpp>
+#include <nall/stdint.hpp>
+#include <nall/string.hpp>
+
+namespace nall {
+
+struct bpsmetadata {
+  inline bool load(const string &filename);
+  inline bool save(const string &filename, const string &metadata);
+  inline string metadata() const;
+
+protected:
+  file sourceFile;
+  string metadataString;
+};
+
+bool bpsmetadata::load(const string &filename) {
+  if(sourceFile.open(filename, file::mode::read) == false) return false;
+
+  auto read = [&]() -> uint8_t {
+    return sourceFile.read();
+  };
+
+  auto decode = [&]() -> uint64_t {
+    uint64_t data = 0, shift = 1;
+    while(true) {
+      uint8_t x = read();
+      data += (x & 0x7f) * shift;
+      if(x & 0x80) break;
+      shift <<= 7;
+      data += shift;
+    }
+    return data;
+  };
+
+  if(read() != 'B') return false;
+  if(read() != 'P') return false;
+  if(read() != 'S') return false;
+  if(read() != '1') return false;
+  decode();
+  decode();
+  unsigned metadataSize = decode();
+  char data[metadataSize + 1];
+  for(unsigned n = 0; n < metadataSize; n++) data[n] = read();
+  data[metadataSize] = 0;
+  metadataString = (const char*)data;
+
+  return true;
+}
+
+bool bpsmetadata::save(const string &filename, const string &metadata) {
+  file targetFile;
+  if(targetFile.open(filename, file::mode::write) == false) return false;
+  if(sourceFile.open() == false) return false;
+  sourceFile.seek(0);
+
+  auto read = [&]() -> uint8_t {
+    return sourceFile.read();
+  };
+
+  auto decode = [&]() -> uint64_t {
+    uint64_t data = 0, shift = 1;
+    while(true) {
+      uint8_t x = read();
+      data += (x & 0x7f) * shift;
+      if(x & 0x80) break;
+      shift <<= 7;
+      data += shift;
+    }
+    return data;
+  };
+
+  uint32_t checksum = ~0;
+
+  auto write = [&](uint8_t data) {
+    targetFile.write(data);
+    checksum = crc32_adjust(checksum, data);
+  };
+
+  auto encode = [&](uint64_t data) {
+    while(true) {
+      uint64_t x = data & 0x7f;
+      data >>= 7;
+      if(data == 0) {
+        write(0x80 | x);
+        break;
+      }
+      write(x);
+      data--;
+    }
+  };
+
+  for(unsigned n = 0; n < 4; n++) write(read());
+  encode(decode());
+  encode(decode());
+  unsigned sourceLength = decode();
+  unsigned targetLength = metadata.length();
+  encode(targetLength);
+  sourceFile.seek(sourceLength, file::index::relative);
+  for(unsigned n = 0; n < targetLength; n++) write(metadata[n]);
+  unsigned length = sourceFile.size() - sourceFile.offset() - 4;
+  for(unsigned n = 0; n < length; n++) write(read());
+  uint32_t outputChecksum = ~checksum;
+  for(unsigned n = 0; n < 32; n += 8) write(outputChecksum >> n);
+
+  targetFile.close();
+  return true;
+}
+
+string bpsmetadata::metadata() const {
+  return metadataString;
+}
+
+}
+
+#endif

--- a/bsnes/nall/bps/patch.hpp
+++ b/bsnes/nall/bps/patch.hpp
@@ -1,0 +1,219 @@
+#ifndef NALL_BPS_PATCH_HPP
+#define NALL_BPS_PATCH_HPP
+
+#include <nall/crc32.hpp>
+#include <nall/file.hpp>
+#include <nall/filemap.hpp>
+#include <nall/stdint.hpp>
+#include <nall/string.hpp>
+
+namespace nall {
+
+struct bpspatch {
+  inline bool modify(const uint8_t *data, unsigned size);
+  inline void source(const uint8_t *data, unsigned size);
+  inline void target(uint8_t *data, unsigned size);
+
+  inline bool modify(const string &filename);
+  inline bool source(const string &filename);
+  inline bool target(const string &filename);
+
+  inline string metadata() const;
+  inline unsigned size() const;
+
+  enum result : unsigned {
+    unknown,
+    success,
+    patch_too_small,
+    patch_invalid_header,
+    source_too_small,
+    target_too_small,
+    source_checksum_invalid,
+    target_checksum_invalid,
+    patch_checksum_invalid,
+  };
+
+  inline result apply();
+
+protected:
+  enum : unsigned { SourceRead, TargetRead, SourceCopy, TargetCopy };
+
+  filemap modifyFile;
+  const uint8_t *modifyData;
+  unsigned modifySize;
+
+  filemap sourceFile;
+  const uint8_t *sourceData;
+  unsigned sourceSize;
+
+  filemap targetFile;
+  uint8_t *targetData;
+  unsigned targetSize;
+
+  unsigned modifySourceSize;
+  unsigned modifyTargetSize;
+  unsigned modifyMarkupSize;
+  string metadataString;
+};
+
+bool bpspatch::modify(const uint8_t *data, unsigned size) {
+  if(size < 19) return false;
+  modifyData = data;
+  modifySize = size;
+
+  unsigned offset = 4;
+  auto decode = [&]() -> uint64_t {
+    uint64_t data = 0, shift = 1;
+    while(true) {
+      uint8_t x = modifyData[offset++];
+      data += (x & 0x7f) * shift;
+      if(x & 0x80) break;
+      shift <<= 7;
+      data += shift;
+    }
+    return data;
+  };
+
+  modifySourceSize = decode();
+  modifyTargetSize = decode();
+  modifyMarkupSize = decode();
+
+  char buffer[modifyMarkupSize + 1];
+  for(unsigned n = 0; n < modifyMarkupSize; n++) buffer[n] = modifyData[offset++];
+  buffer[modifyMarkupSize] = 0;
+  metadataString = (const char*)buffer;
+
+  return true;
+}
+
+void bpspatch::source(const uint8_t *data, unsigned size) {
+  sourceData = data;
+  sourceSize = size;
+}
+
+void bpspatch::target(uint8_t *data, unsigned size) {
+  targetData = data;
+  targetSize = size;
+}
+
+bool bpspatch::modify(const string &filename) {
+  if(modifyFile.open(filename, filemap::mode::read) == false) return false;
+  return modify(modifyFile.data(), modifyFile.size());
+}
+
+bool bpspatch::source(const string &filename) {
+  if(sourceFile.open(filename, filemap::mode::read) == false) return false;
+  source(sourceFile.data(), sourceFile.size());
+  return true;
+}
+
+bool bpspatch::target(const string &filename) {
+  file fp;
+  if(fp.open(filename, file::mode::write) == false) return false;
+  fp.truncate(modifyTargetSize);
+  fp.close();
+
+  if(targetFile.open(filename, filemap::mode::readwrite) == false) return false;
+  target(targetFile.data(), targetFile.size());
+  return true;
+}
+
+string bpspatch::metadata() const {
+  return metadataString;
+}
+
+unsigned bpspatch::size() const {
+  return modifyTargetSize;
+}
+
+bpspatch::result bpspatch::apply() {
+  if(modifySize < 19) return result::patch_too_small;
+
+  uint32_t modifyChecksum = ~0, targetChecksum = ~0;
+  unsigned modifyOffset = 0, sourceRelativeOffset = 0, targetRelativeOffset = 0, outputOffset = 0;
+
+  auto read = [&]() -> uint8_t {
+    uint8_t data = modifyData[modifyOffset++];
+    modifyChecksum = crc32_adjust(modifyChecksum, data);
+    return data;
+  };
+
+  auto decode = [&]() -> uint64_t {
+    uint64_t data = 0, shift = 1;
+    while(true) {
+      uint8_t x = read();
+      data += (x & 0x7f) * shift;
+      if(x & 0x80) break;
+      shift <<= 7;
+      data += shift;
+    }
+    return data;
+  };
+
+  auto write = [&](uint8_t data) {
+    targetData[outputOffset++] = data;
+    targetChecksum = crc32_adjust(targetChecksum, data);
+  };
+
+  if(read() != 'B') return result::patch_invalid_header;
+  if(read() != 'P') return result::patch_invalid_header;
+  if(read() != 'S') return result::patch_invalid_header;
+  if(read() != '1') return result::patch_invalid_header;
+
+  modifySourceSize = decode();
+  modifyTargetSize = decode();
+  modifyMarkupSize = decode();
+  for(unsigned n = 0; n < modifyMarkupSize; n++) read();
+
+  if(modifySourceSize > sourceSize) return result::source_too_small;
+  if(modifyTargetSize > targetSize) return result::target_too_small;
+
+  while(modifyOffset < modifySize - 12) {
+    unsigned length = decode();
+    unsigned mode = length & 3;
+    length = (length >> 2) + 1;
+
+    switch(mode) {
+    case SourceRead:
+      while(length--) write(sourceData[outputOffset]);
+      break;
+    case TargetRead:
+      while(length--) write(read());
+      break;
+    case SourceCopy:
+    case TargetCopy:
+      signed offset = decode();
+      bool negative = offset & 1;
+      offset >>= 1;
+      if(negative) offset = -offset;
+
+      if(mode == SourceCopy) {
+        sourceRelativeOffset += offset;
+        while(length--) write(sourceData[sourceRelativeOffset++]);
+      } else {
+        targetRelativeOffset += offset;
+        while(length--) write(targetData[targetRelativeOffset++]);
+      }
+      break;
+    }
+  }
+
+  uint32_t modifySourceChecksum = 0, modifyTargetChecksum = 0, modifyModifyChecksum = 0;
+  for(unsigned n = 0; n < 32; n += 8) modifySourceChecksum |= read() << n;
+  for(unsigned n = 0; n < 32; n += 8) modifyTargetChecksum |= read() << n;
+  uint32_t checksum = ~modifyChecksum;
+  for(unsigned n = 0; n < 32; n += 8) modifyModifyChecksum |= read() << n;
+
+  uint32_t sourceChecksum = crc32_calculate(sourceData, modifySourceSize);
+  targetChecksum = ~targetChecksum;
+
+  if(sourceChecksum != modifySourceChecksum) return result::source_checksum_invalid;
+  if(targetChecksum != modifyTargetChecksum) return result::target_checksum_invalid;
+  if(checksum != modifyModifyChecksum) return result::patch_checksum_invalid;
+
+  return result::success;
+}
+
+}
+
+#endif

--- a/bsnes/ui-qt/cartridge/cartridge.cpp
+++ b/bsnes/ui-qt/cartridge/cartridge.cpp
@@ -288,15 +288,12 @@ bool Cartridge::loadCartridge(string &filename, string &xml, SNES::MappedRAM &me
         delete[] targetData;
       }
     } else {
-      file fp;
-      if(config().file.applyPatches && fp.open(upsName, file::mode::read)) {
-        unsigned patchsize = fp.size();
-        uint8_t *patchdata = new uint8_t[patchsize];
-        fp.read(patchdata, patchsize);
-        fp.close();
-
+      filemap fp;
+      if(config().file.applyPatches && fp.open(upsName, filemap::mode::read)) {
         uint8_t *outdata = 0;
         unsigned outsize = 0;
+        const uint8_t *patchdata = fp.data();
+        unsigned patchsize = fp.size();
         ups patcher;
         if(patcher.apply(patchdata, patchsize, data, size, 0, outsize) == ups::result::target_too_small) {
           outdata = new uint8_t[outsize];
@@ -309,7 +306,6 @@ bool Cartridge::loadCartridge(string &filename, string &xml, SNES::MappedRAM &me
             delete[] outdata;
           }
         }
-        delete[] patchdata;
       }
     }
   }

--- a/bsnes/ui-qt/cartridge/cartridge.hpp
+++ b/bsnes/ui-qt/cartridge/cartridge.hpp
@@ -5,7 +5,7 @@ public:
   string baseName;    //physical cartridge file name
   string slotAName;   //Sufami Turbo slot A file name or BS-X slot file name
   string slotBName;   //Sufami Turbo slot B file name
-  bool patchApplied;  //true if UPS patch was applied to image
+  string patchApplied;  //filename of the patch if one was applied to image
 
   string baseXml;
   string slotAXml;
@@ -36,6 +36,8 @@ private:
   bool loadCartridge(string&, string&, SNES::MappedRAM&);
   bool loadMemory(const char*, const char*, SNES::MappedRAM&);
   bool saveMemory(const char*, const char*, SNES::MappedRAM&);
+  bool applyBPS(string&, uint8_t *&data, unsigned &size);
+  bool applyUPS(string&, uint8_t *&data, unsigned &size);
   string decodeJISX0201(const char*);
 };
 

--- a/bsnes/ui-qt/settings/paths.cpp
+++ b/bsnes/ui-qt/settings/paths.cpp
@@ -73,7 +73,7 @@ PathSettingsWindow::PathSettingsWindow() {
   gamePath  = new PathSettingWidget(config().path.rom,   "Games:",         "Remember last path",  "Default Game Path");
   savePath  = new PathSettingWidget(config().path.save,  "Save RAM:",      "Same as loaded game", "Default Save RAM Path");
   statePath = new PathSettingWidget(config().path.state, "Save states:",   "Same as loaded game", "Default Save State Path");
-  patchPath = new PathSettingWidget(config().path.patch, "UPS patches:",   "Same as loaded game", "Default UPS Patch Path");
+  patchPath = new PathSettingWidget(config().path.patch, "BPS/UPS patches:",   "Same as loaded game", "Default BPS/UPS Patch Path");
   cheatPath = new PathSettingWidget(config().path.cheat, "Cheat codes:",   "Same as loaded game", "Default Cheat Code Path");
   dataPath  = new PathSettingWidget(config().path.data,  "Exported data:", "Same as loaded game", "Default Exported Data Path");
 

--- a/bsnes/ui-qt/utility/system-state.cpp
+++ b/bsnes/ui-qt/utility/system-state.cpp
@@ -25,9 +25,15 @@ void Utility::modifySystemState(system_state_t systemState) {
         << "It is unlikely that this title will work properly.</p>");
       }
 
-      showMessage(string()
-      << "Loaded " << cartridge.name
-      << (cartridge.patchApplied ? ", and applied BPS/UPS patch." : "."));
+
+      string msgString = string() << "Loaded " << cartridge.name;
+
+      if(cartridge.patchApplied != "")
+        msgString << ", and applied " << cartridge.patchApplied << " patch.";
+      else
+        msgString << ".";
+
+      showMessage(msgString);
       mainWindow->setWindowTitle(string() << cartridge.name << " - " << SNES::Info::Name << " v" << SNES::Info::Version);
       #if defined(DEBUGGER)
       debugger->echo(string() << "Loaded " << cartridge.name << ".<br>");

--- a/bsnes/ui-qt/utility/system-state.cpp
+++ b/bsnes/ui-qt/utility/system-state.cpp
@@ -27,7 +27,7 @@ void Utility::modifySystemState(system_state_t systemState) {
 
       showMessage(string()
       << "Loaded " << cartridge.name
-      << (cartridge.patchApplied ? ", and applied UPS patch." : "."));
+      << (cartridge.patchApplied ? ", and applied BPS/UPS patch." : "."));
       mainWindow->setWindowTitle(string() << cartridge.name << " - " << SNES::Info::Name << " v" << SNES::Info::Version);
       #if defined(DEBUGGER)
       debugger->echo(string() << "Loaded " << cartridge.name << ".<br>");


### PR DESCRIPTION
Backports BPS patching support from newer bsnes versions. Additionally changes status message to be more informative. Originally made for the bsnes-qt fork.