### PR TITLE
Ruby driver backports

### DIFF
--- a/bsnes/ruby/input/rawinput.cpp
+++ b/bsnes/ruby/input/rawinput.cpp
@@ -342,7 +342,7 @@ public:
 
           //per MSDN: XInput devices have "IG_" in their device strings,
           //which is how they should be identified.
-          string p = utf8_t(pool[i].name);
+          string p = (const char*)utf8_t(pool[i].name);
           if(auto position = strpos(p, "IG_")) {
             lgamepad[n].isXInputDevice = true;
           } else {

--- a/bsnes/ruby/input/sdl.cpp
+++ b/bsnes/ruby/input/sdl.cpp
@@ -97,7 +97,7 @@ struct pInputSDL {
     //Keyboard
     //========
 
-    x_poll(table);
+    x_poll(device.display, table);
 
     //=====
     //Mouse
@@ -172,7 +172,6 @@ struct pInputSDL {
   }
 
   bool init() {
-    x_init();
     SDL_InitSubSystem(SDL_INIT_JOYSTICK);
     SDL_JoystickEventState(SDL_IGNORE);
 
@@ -182,6 +181,7 @@ struct pInputSDL {
     XGetWindowAttributes(device.display, device.rootwindow, &attributes);
     device.screenwidth  = attributes.width;
     device.screenheight = attributes.height;
+    x_init(device.display);
 
     //Xlib: "because XShowCursor(false) would be too easy."
     //create a fully transparent cursor named InvisibleCursor,

--- a/bsnes/ruby/input/x.cpp
+++ b/bsnes/ruby/input/x.cpp
@@ -30,13 +30,13 @@ public:
 
   bool poll(int16_t *table) {
     memset(table, 0, Scancode::Limit * sizeof(int16_t));
-    x_poll(table);
+    x_poll(display, table);
     return true;
   }
 
   bool init() {
-    x_init();
     display = XOpenDisplay(0);
+    x_init(display);
     return true;
   }
 

--- a/bsnes/ruby/input/xlibkeys.hpp
+++ b/bsnes/ruby/input/xlibkeys.hpp
@@ -16,11 +16,11 @@ enum XScancode {
   LeftShift, RightShift, LeftControl, RightControl, LeftAlt, RightAlt, LeftSuper, RightSuper,
 };
 
-void x_poll(int16_t *table) {
+void x_poll(Display *display, int16_t *table) {
+  if(!display) return;
+
   char state[32];
-  Display *display = XOpenDisplay(0);
   XQueryKeymap(display, state);
-  XCloseDisplay(display);
 
   #define key(id) table[keyboard(0)[id]]
   #define pressed(id) (bool)(state[scancode[id] >> 3] & (1 << (scancode[id] & 7)))
@@ -139,8 +139,9 @@ void x_poll(int16_t *table) {
   #undef pressed
 }
 
-void x_init() {
-  Display *display = XOpenDisplay(0);
+void x_init(Display *display) {
+  if(!display) return;
+
   memset(&scancode, 0, sizeof scancode);
 
   #define assign(x, y) scancode[x] = XKeysymToKeycode(display, y)
@@ -259,6 +260,4 @@ void x_init() {
   assign(Menu, XK_Menu);
 
   #undef assign
-
-  XCloseDisplay(display);
 }

--- a/bsnes/ruby/video/direct3d.cpp
+++ b/bsnes/ruby/video/direct3d.cpp
@@ -406,7 +406,7 @@ public:
     presentation.BackBufferHeight       = 0;
 
     if(lpd3d->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, settings.handle,
-      D3DCREATE_SOFTWARE_VERTEXPROCESSING, &presentation, &device) != D3D_OK) {
+      D3DCREATE_FPU_PRESERVE | D3DCREATE_SOFTWARE_VERTEXPROCESSING, &presentation, &device) != D3D_OK) {
       return false;
     }
 

--- a/bsnes/ruby/video/opengl.hpp
+++ b/bsnes/ruby/video/opengl.hpp
@@ -36,19 +36,16 @@ public:
   unsigned iwidth, iheight;
 
   void resize(unsigned width, unsigned height) {
-    if(iwidth >= width && iheight >= height) return;
-
-    if(gltexture) glDeleteTextures(1, &gltexture);
+    if(gltexture == 0) glGenTextures(1, &gltexture);
     iwidth  = max(width,  iwidth );
     iheight = max(height, iheight);
     if(buffer) delete[] buffer;
     buffer = new uint32_t[iwidth * iheight];
 
-    glGenTextures(1, &gltexture);
     glBindTexture(GL_TEXTURE_2D, gltexture);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, iwidth);
     glTexImage2D(GL_TEXTURE_2D,
-      /* mip-map level = */ 0, /* internal format = */ GL_RGB,
+      /* mip-map level = */ 0, /* internal format = */ GL_RGBA,
       iwidth, iheight, /* border = */ 0, /* format = */ GL_BGRA,
       GL_UNSIGNED_INT_8_8_8_8_REV, buffer);
   }


### PR DESCRIPTION
Backports some ruby video and input driver changes. Cherry-picked from newer bsnes sources for the bsnes-qt fork.

D3DCREATE_FPU_PRESERVE was needed to fix buggy d3d drivers. The cast in rawinput was needed to fix build with some toolchains. Not sure if it's still needed or sensible to include.