### PR TITLE
Added search paths for Qt frameworks installed via Brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# bsnes-plus
+# bsnes-plus
 
 bsnes-plus (or bsnes+) is a fork of bsnes (based on bsnes-classic) intended to
 introduce some new features and improvements, mostly aimed at debugging.
@@ -35,9 +35,15 @@ Non-debugging features:
 - Install Qt 4.8.6 (http://download.qt.io/archive/qt/) and make sure its `bin` directory is in your path
 - Run `mingw32-make`
 
-Building with the original MinGW used to be the preferred way to do it, but made building "out of the box" annoying for various reasons (including requiring outdated DirectX headers/libs and problems with some native Windows code) and is no longer supported. 
+Building with the original MinGW used to be the preferred way to do it, but made building "out of the box" annoying for various reasons (including requiring outdated DirectX headers/libs and problems with some native Windows code) and is no longer supported.
 
-## Building on OS X / Linux / other *nix
+## Building on OS X
+
+- Install a C++ toolchain ([Xcode](https://developer.apple.com) is probably the easiest route)  
+- Install Qt 4.8 (get [Brew](http://brew.sh) and run `brew install qt`)  
+- Run `make`from the bsnes directory.  
+
+## Building on Linux / other *nix
 
 As there is no ``configure`` step, make sure necessary Qt4/X11 packages are installed. On a Debian/Ubuntu system, it would require a command like:
 ```

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -8,11 +8,17 @@ ifeq ($(ui),)
 endif
 
 # compiler
-c       := $(compiler) -x c -std=gnu99
+c       := $(compiler) -xc -std=gnu99
 cpp     := $(compiler) -std=gnu++0x
-flags   := -O3 -fomit-frame-pointer -I. -I$(snes)
+flags   := -I. -I$(snes)
 link    :=
 objects :=
+
+ifeq ($(DEBUG), 1)
+  flags += -O0 -g
+else
+  flags += -O3 -fomit-frame-pointer
+endif
 
 # comment this line to enable asserts
 flags += -DNDEBUG
@@ -21,14 +27,16 @@ flags += -DNDEBUG
 # flags += -fprofile-generate
 # link += -lgcov
 
-# profile-guided optimization
-# flags += -fprofile-use
+# silence warnings
+flags += -Wno-switch -Wno-absolute-value -Wno-parentheses
 
 # platform
 ifeq ($(platform),x)
   link += -s -ldl -lX11 -lXext
 else ifeq ($(platform),osx)
 	osxbundle := ../bsnes+.app
+	flags += -march=native
+	link += -F/usr/local/lib
 else ifeq ($(platform),win)
   link += -mwindows
 # link += -mconsole
@@ -99,6 +107,9 @@ clean: ui_clean
 	-@$(call delete,*.ilk)
 	-@$(call delete,*.pdb)
 	-@$(call delete,*.manifest)
+ifeq ($(platform),osx)
+	@rm -rf $(osxbundle)
+endif
 
 archive-all:
 	tar -cjf bsnes.tar.bz2 data launcher libco nall obj out phoenix ruby snes ui-phoenix ui-qt Makefile cc.bat clean.bat sync.sh

--- a/bsnes/ui-qt/template/Makefile
+++ b/bsnes/ui-qt/template/Makefile
@@ -22,7 +22,7 @@ ifeq ($(platform),x)
   qtlib := `pkg-config --libs $(qtlibs)`
 else ifeq ($(platform),osx)
   qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/4/Headers)
-
+  qtinc += $(foreach lib,$(qtlibs),-I/usr/local/lib/$(lib).framework/Versions/4/Headers)
   qtlib := -L/Library/Frameworks
   qtlib += $(foreach lib,$(qtlibs),-framework $(lib))
   qtlib += -framework Carbon


### PR DESCRIPTION
Added search paths for Qt frameworks installed via Brew (plus some tweaked flags for building from Xcode). Added "Building on OS X" section to README.

Not sure if the "-Wno" flags added to silence a huge amount of warnings when building with Clang is kosher?