### PR TITLE
OS X Build

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -59,7 +59,7 @@ compile = \
 
 %.o: $<; $(call compile)
 
-all: build;
+all: build plugins;
 
 include $(snes)/Makefile
 include $(ui)/Makefile
@@ -78,7 +78,7 @@ else
 	$(strip $(cpp) -o out/bsnes $(objects) $(link))
 endif
 
-install:
+install: build plugins
 ifeq ($(platform),x)
 	install -D -m 755 out/bsnes $(DESTDIR)$(prefix)/bin/bsnes
 	install -D -m 644 data/bsnes.png $(DESTDIR)$(prefix)/share/pixmaps/bsnes.png
@@ -86,6 +86,13 @@ ifeq ($(platform),x)
 	test -d ~/.bsnes || mkdir ~/.bsnes
 	cp data/cheats.xml ~/.bsnes/cheats.xml
 	chmod 777 ~/.bsnes ~/.bsnes/cheats.xml
+else ifeq ($(platform),osx)
+	mv -f $(osxbundle) /Applications/bsnes+.app
+	test -d ~/.bsnes || mkdir ~/.bsnes
+	cp data/cheats.xml ~/.bsnes/cheats.xml
+	chmod 777 ~/.bsnes ~/.bsnes/cheats.xml
+else
+	@echo Install not available for current platform
 endif
 
 uninstall:
@@ -93,6 +100,21 @@ ifeq ($(platform),x)
 	rm $(DESTDIR)$(prefix)/bin/bsnes
 	rm $(DESTDIR)$(prefix)/share/pixmaps/bsnes.png
 	rm $(DESTDIR)$(prefix)/share/applications/bsnes.desktop
+else ifeq ($(platform),osx)
+	rm -rf /Applications/bsnes+.app
+else
+	@echo Install not available for current platform
+endif
+
+plugins: build
+	@$(MAKE) -C ../snesreader
+#	@$(MAKE) -C ../snesfilter
+	@$(MAKE) -C ../supergameboy
+ifeq ($(platform),osx)
+	mkdir -p $(osxbundle)/Contents/Frameworks
+	cp -f ../snesreader/libsnesreader.dylib $(osxbundle)/Contents/Frameworks/libsnesreader.dylib
+#	cp -f ../snesfilter/libsnesfilter.dylib $(osxbundle)/Contents/Frameworks/libsnesfilter.dylib
+	cp -f ../supergameboy/libsupergameboy.dylib $(osxbundle)/Contents/Frameworks/libsupergameboy.dylib
 endif
 
 clean: ui_clean

--- a/supergameboy/Makefile
+++ b/supergameboy/Makefile
@@ -110,12 +110,12 @@ else
 endif
 
 install:
-ifeq ($(platform),osx)
-	cp libsupergameboy.dylib /usr/local/lib/libsupergameboy.dylib
-else
+ifeq ($(platform),x)
 	install -D -m 755 libsupergameboy.a $(DESTDIR)$(prefix)/lib
 	install -D -m 755 libsupergameboy.so $(DESTDIR)$(prefix)/lib
 	ldconfig -n $(DESTDIR)$(prefix)/lib
+else
+	@echo Install not available for current platform
 endif
 
 clean:


### PR DESCRIPTION
- nall/dl looks inside app bundle for dylibs on OS X build
- "make all" also builds plugins
- "make install" on OS X builds plugins, copies them to bundle frameworks, and moves bundle to /Applications