### PR TITLE
Better Memory Pack Type 7 check + Page Buffer change + Memory Map fix

### DIFF
--- a/bsnes/nall/snes/cartridge.hpp
+++ b/bsnes/nall/snes/cartridge.hpp
@@ -314,7 +314,8 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
     }
     xml << "  <bsx>\n";
     xml << "    <slot>\n";
-    xml << "      <map mode='linear' address='c0-ef:0000-ffff'/>\n";
+    xml << "      <map mode='linear' address='c0-ef:0000-7fff'/>\n";
+    xml << "      <map mode='linear' address='c0-ef:8000-ffff'/>\n";
     xml << "    </slot>\n";
     xml << "  </bsx>\n";
   } else if(mapper == BSCHiROM) {

--- a/bsnes/nall/snes/cartridge.hpp
+++ b/bsnes/nall/snes/cartridge.hpp
@@ -545,7 +545,45 @@ void SNESCartridge::read_header(const uint8_t *data, unsigned size) {
       if(n15 == 0x00 || n15 == 0x80 || n15 == 0x84 || n15 == 0x9c || n15 == 0xbc || n15 == 0xfc) {
         if(data[index + 0x1a] == 0x33 || data[index + 0x1a] == 0xff) {
           type = TypeBsx;
-          bsxpack_type = (data[index + 0x10] == 0x00) ? MaskROM : FlashROM;
+          //Check if FlashROM or MaskROM
+          uint8_t i = 0;
+    	  for (i = 0; i < 20; i++)
+    	  {
+        	uint8_t checkbyte;
+        	switch(i)
+        	{
+            	case 0x00: checkbyte = 0x4D; break;
+            	case 0x02: checkbyte = 0x50; break;
+            	case 0x06: checkbyte = 0x70; break;
+            	default:   checkbyte = 0x00;
+        	}
+
+        	if (i != 0x06)
+        	{
+	            if (data[index - 0xC0 + i] != checkbyte)
+            	{
+	                break;
+            	}
+        	}
+        	else
+        	{
+	            //Only check 0xF0 for i = 6, only Memory Pack type matters
+            	if ((data[index - 0xC0 + i] & 0xF0) != checkbyte)
+            	{
+	                break;
+            	}
+        	}
+    	  }
+
+    	  if (i == 20)
+    	  {
+	        //if i reaches 20, that means all the checks are successful
+        	bsxpack_type = MaskROM;
+    	  }
+    	  else
+    	  {
+    		bsxpack_type = FlashROM;
+    	  }
           region = NTSC;  //BS-X only released in Japan
           return;
         }

--- a/bsnes/snes/chip/bsx/bsx.hpp
+++ b/bsnes/snes/chip/bsx/bsx.hpp
@@ -61,8 +61,6 @@ private:
     bool vendor_info;
     bool writebyte;
   } regs;
-
-  bool type7;
 };
 
 extern BSXBase  bsxbase;

--- a/bsnes/snes/chip/bsx/bsx_flash.cpp
+++ b/bsnes/snes/chip/bsx/bsx_flash.cpp
@@ -43,9 +43,9 @@ uint8 BSXFlash::read(unsigned addr) {
     return 0x80;
   }
 
-  if(regs.vendor_info && addr >= 0xff00 && addr <= 0xff13) {
+  if(regs.vendor_info && ((addr & 0x7FFF) >= 0x7F00) && ((addr & 0x7FFF) <= 0x7F13)) {
     //read flash cartridge vendor information
-    switch(addr - 0xff00) {
+    switch(addr & 0xFF) {
       case 0x00: return 0x4d;
       case 0x01: return 0x00;
       case 0x02: return 0x50;

--- a/bsnes/snes/chip/bsx/bsx_flash.cpp
+++ b/bsnes/snes/chip/bsx/bsx_flash.cpp
@@ -18,50 +18,6 @@ void BSXFlash::reset() {
   regs.writebyte = false;
 
   memory::bsxpack.write_protect(!regs.writebyte);
-
-  //Check if Memory Pack is Type 7 (ROM) for accuracy
-  type7 = false;
-
-  for (int check = 0; check <= 1; check++)
-  {
-    int i = 0;
-    for (i = 0; i < 20; i++)
-    {
-        uint8 checkbyte;
-        switch(i)
-        {
-            case 0x00: checkbyte = 0x4D; break;
-            case 0x02: checkbyte = 0x50; break;
-            case 0x06: checkbyte = 0x70; break;
-            default:   checkbyte = 0x00;
-        }
-
-        //Check both 0x7F00+i and 0xFF00+i
-        if (i != 0x06)
-        {
-            if (memory::bsxpack.read((0x7F00 | (check << 16)) + i) != checkbyte)
-            {
-                break;
-            }
-        }
-        else
-        {
-            //Only check 0xF0 for i = 6, only Memory Pack type matters
-            if (memory::bsxpack.read(((0x7F00 | (check << 16)) + i) & 0xF0) != checkbyte)
-            {
-                break;
-            }
-        }
-    }
-
-    if (i == 20)
-    {
-        //if i reaches 20, that means all the checks are successful
-        type7 = true;
-        break;
-    }
-  }
-
 }
 
 unsigned BSXFlash::size() const {
@@ -69,12 +25,6 @@ unsigned BSXFlash::size() const {
 }
 
 uint8 BSXFlash::read(unsigned addr) {
-  if (type7)
-  {
-    //Don't do anything else than reading data, it's not Flash
-    return memory::bsxpack.read(addr);
-  }
-
   if(regs.esr) {
     switch (addr & 0xFFFF)
     {
@@ -121,13 +71,6 @@ void BSXFlash::write(unsigned addr, uint8 data) {
   //read-only flashcarts.
   //below is an unfortunately necessary workaround to this problem.
   //if(cartridge.mapper() == Cartridge::BSCHiROM) return;
-
-  //If Type7
-  if (type7)
-  {
-    //Don't do anything, it's not Flash
-    return;
-  }
 
   //If Write Byte Command is issued
   if(regs.writebyte)


### PR DESCRIPTION
Reverts Type 7 check from BSXFlash and puts it in nall instead (I completely forgot nall wasn't just always a replacement for most functions)

Also puts Page Buffer (or Vendor Info) at both 0x7F00 and 0xFF00.
Mostly because SD Gundam G-NEXT Memory Pack ROM has one at 0x7F00.