### PR TITLE
An addition to the cheatfinder interface to make it easy to compare with previous values etc.

### DIFF
--- a/bsnes/ui-qt/template/Makefile
+++ b/bsnes/ui-qt/template/Makefile
@@ -11,7 +11,7 @@
 
 ifeq ($(moc),)
   ifeq ($(qtpath),)
-    moc := moc
+    moc := moc-qt4
   else
     moc := $(qtpath)/bin/moc
   endif
@@ -19,7 +19,7 @@ endif
 
 ifeq ($(rcc),)
   ifeq ($(qtpath),)
-    rcc := rcc
+    rcc := rcc-qt4
   else
     rcc := $(qtpath)/bin/rcc
   endif

--- a/bsnes/ui-qt/tools/cheatfinder.cpp
+++ b/bsnes/ui-qt/tools/cheatfinder.cpp
@@ -63,14 +63,33 @@ CheatFinderWindow::CheatFinderWindow() {
   compareGroup->addButton(compareGreaterThan);
   controlLayout->addWidget(compareGreaterThan, 1, 4);
 
+  compareToLabel = new QLabel("Compare to:");
+  controlLayout->addWidget(compareToLabel, 2, 0);
+  
+  compareToGroup = new QButtonGroup(this);
+  
+  compareToPrev = new QRadioButton("Previous value");
+  compareToPrev->setChecked(true);
+  compareToGroup->addButton(compareToPrev);
+  controlLayout->addWidget(compareToPrev, 2, 1);
+  
+  compareToAddress = new QRadioButton("Address");
+  compareToGroup->addButton(compareToAddress);
+  controlLayout->addWidget(compareToAddress, 2, 2);
+  
+  compareToValue = new QRadioButton("Value");
+  compareToGroup->addButton(compareToValue);
+  controlLayout->addWidget(compareToValue, 2, 3);
+
   valueLabel = new QLabel("Search value:");
-  controlLayout->addWidget(valueLabel, 2, 0);
+  controlLayout->addWidget(valueLabel, 3, 0);
 
   actionLayout = new QHBoxLayout;
   actionLayout->setSpacing(Style::WidgetSpacing);
-  controlLayout->addLayout(actionLayout, 2, 1, 1, 4);
+  controlLayout->addLayout(actionLayout, 3, 1, 1, 4);
 
   valueEdit = new QLineEdit;
+  valueEdit->setEnabled(false);
   actionLayout->addWidget(valueEdit);
 
   searchButton = new QPushButton("Search");
@@ -79,10 +98,19 @@ CheatFinderWindow::CheatFinderWindow() {
   resetButton = new QPushButton("Reset");
   actionLayout->addWidget(resetButton);
 
+  connect(compareToPrev, SIGNAL(toggled(bool)), this, SLOT(toggle_editline(bool)));
+  connect(compareToAddress, SIGNAL(toggled(bool)), this, SLOT(toggle_editline(bool)));
+  connect(compareToValue, SIGNAL(toggled(bool)), this, SLOT(toggle_editline(bool)));
+
   connect(valueEdit, SIGNAL(returnPressed()), this, SLOT(searchMemory()));
   connect(searchButton, SIGNAL(released()), this, SLOT(searchMemory()));
   connect(resetButton, SIGNAL(released()), this, SLOT(resetSearch()));
   synchronize();
+}
+
+void CheatFinderWindow::toggle_editline(bool) {
+  if(compareToPrev->isChecked()) valueEdit->setEnabled(false);
+  else valueEdit->setEnabled(true);
 }
 
 void CheatFinderWindow::synchronize() {
@@ -94,7 +122,7 @@ void CheatFinderWindow::synchronize() {
     searchButton->setEnabled(false);
     resetButton->setEnabled(false);
   } else {
-    valueEdit->setEnabled(true);
+    if(!compareToPrev->isChecked()) valueEdit->setEnabled(true);
     searchButton->setEnabled(true);
     resetButton->setEnabled(true);
   }
@@ -140,12 +168,20 @@ void CheatFinderWindow::searchMemory() {
   if(size32bit->isChecked()) size = 3;
 
   unsigned data;
-  string text = valueEdit->text().toUtf8().constData();
+  if(!compareToPrev->isChecked()){
+    string text = valueEdit->text().toUtf8().constData();
 
-  //auto-detect input data type
-  if(strbegin(text, "0x")) data = hex((const char*)text + 2);
-  else if(strbegin(text, "-")) data = integer(text);
-  else data = decimal(text);
+    //auto-detect input data type
+    if(strbegin(text, "0x")) data = hex((const char*)text + 2);
+    else if(strbegin(text, "-")) data = integer(text);
+    else data = decimal(text);
+
+    if(compareToAddress->isChecked()){
+      //How should incorrect addresses be handled? For now we wrap around.
+      data %= SNES::memory::wram.size();
+      data = read(data, size);
+    }
+  }
 
   if(addrList.size() == 0) {
     //search for the first time: enqueue all possible values so they are all searched
@@ -160,6 +196,8 @@ void CheatFinderWindow::searchMemory() {
   for(unsigned i = 0; i < addrList.size(); i++) {
     unsigned thisAddr = addrList[i];
     unsigned thisData = read(thisAddr, size);
+
+    if(compareToPrev->isChecked()) data = dataList[i];
 
     if((compareEqual->isChecked()       && thisData == data)
     || (compareNotEqual->isChecked()    && thisData != data)

--- a/bsnes/ui-qt/tools/cheatfinder.moc.hpp
+++ b/bsnes/ui-qt/tools/cheatfinder.moc.hpp
@@ -23,11 +23,18 @@ public:
   QPushButton *searchButton;
   QPushButton *resetButton;
 
+  QButtonGroup *compareToGroup;
+  QLabel *compareToLabel;
+  QRadioButton *compareToPrev;
+  QRadioButton *compareToAddress;
+  QRadioButton *compareToValue;
+
   void synchronize();
   void refreshList();
   CheatFinderWindow();
 
 public slots:
+  void toggle_editline(bool);
   void searchMemory();
   void resetSearch();
 

--- a/snesfilter/nall/qt/Makefile
+++ b/snesfilter/nall/qt/Makefile
@@ -11,7 +11,7 @@
 
 ifeq ($(moc),)
   ifeq ($(qtpath),)
-    moc := moc
+    moc := moc-qt4
   else
     moc := $(qtpath)/bin/moc
   endif
@@ -19,7 +19,7 @@ endif
 
 ifeq ($(rcc),)
   ifeq ($(qtpath),)
-    rcc := rcc
+    rcc := rcc-qt4
   else
     rcc := $(qtpath)/bin/rcc
   endif

--- a/snesreader/nall/qt/Makefile
+++ b/snesreader/nall/qt/Makefile
@@ -11,7 +11,7 @@
 
 ifeq ($(moc),)
   ifeq ($(qtpath),)
-    moc := moc
+    moc := moc-qt4
   else
     moc := $(qtpath)/bin/moc
   endif
@@ -19,7 +19,7 @@ endif
 
 ifeq ($(rcc),)
   ifeq ($(qtpath),)
-    rcc := rcc
+    rcc := rcc-qt4
   else
     rcc := $(qtpath)/bin/rcc
   endif


### PR DESCRIPTION
I have added a simple radio selection to the cheatfinder interface that gives the user the ability to compare current values to previous ones, to the value at a certain address, or to a fixed value. This is standard in debugging emulators such as FCEUX, and makes it easy to discover values that have (or haven't) changed.

Note that I made some changes to the Makefile. Since I have both versions of QT on my PC, I had to specify that it should use QT4.