### PR TITLE
Updates to the debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.so.1
 *.patch
 *.rar
+*/out
+*/bin

--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
@@ -60,6 +60,7 @@ bool PPUDebugger::property(unsigned id, string &name, string &value) {
   item("OAM Base Size", (unsigned)regs.oam_basesize);
   item("OAM Name Select", (unsigned)regs.oam_nameselect);
   item("OAM Name Base Address", string("0x", hex<4>(regs.oam_tdaddr)));
+  item("OAM Second Name Table Address", string("0x", hex<4>((regs.oam_tdaddr + (256 * 32) + (regs.oam_nameselect << 13)) & 0xffff)));
 
   //$2102-$2103
   item("$2102-$2103", "");

--- a/bsnes/ui-qt/Makefile
+++ b/bsnes/ui-qt/Makefile
@@ -73,7 +73,7 @@ $(foreach f,$(moc_objects), \
   $(eval $f: $(__file)) \
 )
 
-obj/ui-main.o: $(ui)/main.cpp $(headers) obj/resource.rcc $(wildcard $(ui)/*.cpp) $(wildcard $(ui)/link/*.cpp) $(wildcard $(ui)/platform/*.cpp) $(wildcard $(ui)/utility/*.cpp); $(qt_compile)
+obj/ui-main.o: $(ui)/main.cpp $(headers) obj/resource.rcc $(wildcard $(ui)/*.cpp) $(wildcard $(ui)/application/*.cpp) $(wildcard $(ui)/link/*.cpp) $(wildcard $(ui)/platform/*.cpp) $(wildcard $(ui)/utility/*.cpp); $(qt_compile)
 obj/ui-base.o: $(ui)/base/base.cpp $(headers) $(wildcard $(ui)/base/*.cpp); $(qt_compile)
 obj/ui-cartridge.o: $(ui)/cartridge/cartridge.cpp $(headers) $(wildcard $(ui)/cartridge/*.cpp); $(qt_compile)
 obj/ui-debugger.o: $(ui)/debugger/debugger.cpp $(headers) $(call rwildcard,$(ui)/debugger/,%.cpp); $(qt_compile)

--- a/bsnes/ui-qt/application/application.cpp
+++ b/bsnes/ui-qt/application/application.cpp
@@ -3,6 +3,7 @@ VideoDisplay display;
 Application application;
 
 #include "init.cpp"
+#include "arguments.cpp"
 
 VideoDisplay::VideoDisplay() {
   outputWidth = 0;
@@ -91,10 +92,7 @@ int Application::main(int &argc, char **argv) {
   SNES::system.init(&interface);
   mainWindow->system_loadSpecial_superGameBoy->setVisible(SNES::supergameboy.opened());
 
-  if(argc == 2) {
-    //if valid file was specified on the command-line, attempt to load it now
-    cartridge.loadNormal(argv[1]);
-  }
+  parseArguments();
 
   timer = new QTimer(this);
   connect(timer, SIGNAL(timeout()), this, SLOT(run()));

--- a/bsnes/ui-qt/application/application.moc.hpp
+++ b/bsnes/ui-qt/application/application.moc.hpp
@@ -47,6 +47,10 @@ public:
   void initPaths(const char *basename);
   void init();
 
+  void printArguments();
+  void parseArguments();
+  bool parseArgumentSwitch(const string& arg, const string& param);
+
   Application();
   ~Application();
 

--- a/bsnes/ui-qt/application/arguments.cpp
+++ b/bsnes/ui-qt/application/arguments.cpp
@@ -1,0 +1,65 @@
+
+void Application::parseArguments() {
+  const QStringList argv = app->arguments();
+
+  string fileName = "";
+  bool processSwitches = true;
+
+  for(unsigned i = 1; i < argv.size(); i++) {
+    const string arg = argv.at(i).toUtf8().data();
+
+    if(arg == "--") { processSwitches = false; continue; }
+
+    if(arg[0] == '-' && processSwitches) {
+      const string param = i + 1 < argv.size() ? argv.at(i + 1).toUtf8().data() : "";
+
+      bool usesParam = parseArgumentSwitch(arg, param);
+      if (usesParam) { i++; continue; }
+    } else {
+      if(fileName == "") fileName = arg;
+    }
+  }
+
+  if(fileName != "") {
+    cartridge.loadNormal(fileName);
+  }
+}
+
+// returns true if argument uses parameter
+bool Application::parseArgumentSwitch(const string& arg, const string& parameter) {
+  if(arg == "--help" || arg == "-h") { printArguments(); return false; }
+
+  #if defined(DEBUGGER)
+  if(arg == "--show-debugger") { debugger->show(); return false; }
+
+  if(arg == "--breakpoint" || arg == "-b") {
+    if(parameter == "" || parameter[0] == '-') return false;
+
+    lstring param;
+    param.split<3>(":", string(parameter).lower());
+    if(param.size() == 1) { param.append("rwx"); }
+    if(param.size() == 2) { param.append("cpu"); }
+
+    breakpointEditor->addBreakpoint(param[0], param[1], param[2]);
+
+    return true;
+  }
+  #endif
+
+  return false;
+}
+
+void Application::printArguments() {
+  string filepath = app->applicationFilePath().toUtf8().data();
+
+  puts(string("Usage: ", notdir(filepath), " [options] filename\n"));
+  puts("  -h / --help                       show help");
+  #if defined(DEBUGGER)
+  puts("  --show-debugger                   open debugger window on startup\n"
+       "  -b / --breakpoint <breakpoint>    add breakpoint\n"
+       "\n"
+       "Breakpoint format: <addr>[-<addr end>][:<rwx>[:<source>]]\n"
+       "                   rwx = read / write / execute flags\n"
+       "                   source = cpu, smp, vram, oam, cgram, sa1, sfx");
+  #endif
+}

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -14,6 +14,7 @@ Debugger *debugger;
 #include "tools/memory.cpp"
 #include "tools/properties.cpp"
 
+#include "ppu/cgram-widget.cpp"
 #include "ppu/vram-viewer.cpp"
 #include "ppu/oam-viewer.cpp"
 #include "ppu/cgram-viewer.cpp"

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -84,7 +84,8 @@ Debugger::Debugger() {
 
   // TODO: icons instead of text
   runBreak = new QToolButton;
-  runBreak->setDefaultAction(new QAction("Brk", this));
+  runBreak->setDefaultAction(new QAction("Break", this));
+  runBreak->setFixedWidth(runBreak->minimumSizeHint().width());
   runBreak->defaultAction()->setToolTip("Pause/resume execution (F5)");
   runBreak->defaultAction()->setShortcut(Qt::Key_F5);
   commandLayout->addWidget(runBreak);

--- a/bsnes/ui-qt/debugger/ppu/cgram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-viewer.cpp
@@ -1,87 +1,11 @@
 #include "cgram-viewer.moc"
 CgramViewer *cgramViewer;
 
-void CgramViewer::show() {
-  Window::show();
-  refresh();
-}
-
-void CgramViewer::refresh() {
-  if(SNES::cartridge.loaded() == false) {
-    canvas->image->fill(0x000000);
-    colorInfo->setText("");
-    canvas->update();
-    return;
-  }
-
-  uint32_t *buffer = (uint32_t*)canvas->image->bits();
-  for(unsigned i = 0; i < 256; i++) {
-    unsigned x = i % 16;
-    unsigned y = i / 16;
-
-    uint16_t color = SNES::memory::cgram[i * 2 + 0];
-    color |= SNES::memory::cgram[i * 2 + 1] << 8;
-
-    uint8_t r = (color >>  0) & 31;
-    uint8_t g = (color >>  5) & 31;
-    uint8_t b = (color >> 10) & 31;
-
-    r = (r << 3) | (r >> 2);
-    g = (g << 3) | (g >> 2);
-    b = (b << 3) | (b >> 2);
-
-    uint32_t output = (r << 16) | (g << 8) | (b << 0);
-
-    for(unsigned py = 0; py < 16; py++) {
-      for(unsigned px = 0; px < 16; px++) {
-        buffer[(y * 16 + py) * (16 * 16) + (x * 16 + px)] = output;
-      }
-    }
-
-    if(i != currentSelection) continue;
-
-    //draw a dotted box black-and-white around the selected color
-    for(unsigned py = 0; py < 16; py++) {
-      for(unsigned px = 0; px < 16; px++) {
-        if(py == 0 || py == 15 || px == 0 || px == 15) {
-          uint32_t color = ((px + py) & 2) ? 0xffffff : 0x000000;
-          buffer[(y * 16 + py) * (16 * 16) + (x * 16 + px)] = color;
-        }
-      }
-    }
-
-    string text;
-    char temp[256];
-    text << "<table>";
-    text << "<tr><td>Index:</td><td>" << currentSelection << "</td></tr>";
-    sprintf(temp, "%.4x", color);
-    text << "<tr><td>Value:</td><td>0x" << temp << "</td></tr>";
-    text << "<tr><td>Red:</td><td>" << (unsigned)(r >> 3) << "</td></tr>";
-    text << "<tr><td>Green:</td><td>" << (unsigned)(g >> 3) << "</td></tr>";
-    text << "<tr><td>Blue:</td><td>" << (unsigned)(b >> 3) << "</td></tr>";
-    text << "</table>";
-    colorInfo->setText(text);
-  }
-
-  canvas->update();
-}
-
-void CgramViewer::autoUpdate() {
-  if(autoUpdateBox->isChecked()) refresh();
-}
-
-void CgramViewer::setSelection(unsigned index) {
-  currentSelection = index;
-  refresh();
-}
-
 CgramViewer::CgramViewer() {
   setObjectName("cgram-viewer");
   setWindowTitle("Palette Viewer");
   setGeometryString(&config().geometry.cgramViewer);
   application.windowList.append(this);
-
-  currentSelection = 0;
 
   layout = new QHBoxLayout;
   layout->setSizeConstraint(QLayout::SetFixedSize);
@@ -89,9 +13,8 @@ CgramViewer::CgramViewer() {
   layout->setSpacing(Style::WidgetSpacing);
   setLayout(layout);
 
-  canvas = new Canvas;
-  canvas->setFixedSize(16 * 16, 16 * 16);
-  layout->addWidget(canvas);
+  cgramWidget = new CgramWidget;
+  layout->addWidget(cgramWidget);
 
   controlLayout = new QVBoxLayout;
   controlLayout->setAlignment(Qt::AlignTop);
@@ -109,18 +32,40 @@ CgramViewer::CgramViewer() {
   controlLayout->addWidget(colorInfo);
 
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
+  connect(cgramWidget, SIGNAL(selectedChanged()), this, SLOT(refresh()));
 }
 
-void CgramViewer::Canvas::mousePressEvent(QMouseEvent *event) {
-  cgramViewer->setSelection((event->y() / 16) * 16 + (event->x() / 16));
+void CgramViewer::show() {
+  Window::show();
+  refresh();
 }
 
-void CgramViewer::Canvas::paintEvent(QPaintEvent*) {
-  QPainter painter(this);
-  painter.drawImage(0, 0, *image);
+void CgramViewer::autoUpdate() {
+  if(autoUpdateBox->isChecked()) refresh();
 }
 
-CgramViewer::Canvas::Canvas() {
-  image = new QImage(16 * 16, 16 * 16, QImage::Format_RGB32);
-  image->fill(0x000000);
+void CgramViewer::refresh() {
+  cgramWidget->refresh();
+
+  string text;
+
+  if (cgramWidget->hasSelected()) {
+    unsigned selected = cgramWidget->selectedColor();
+
+    uint16_t color = SNES::memory::cgram[selected * 2 + 0];
+    color |= SNES::memory::cgram[selected * 2 + 1] << 8;
+
+    uint8_t r = (color >>  0) & 31;
+    uint8_t g = (color >>  5) & 31;
+    uint8_t b = (color >> 10) & 31;
+
+    text << "<table>";
+    text << "<tr><td>Index:</td><td>" << selected << "</td></tr>";
+    text << "<tr><td>Value:</td><td>0x" << hex<4>(color) << "</td></tr>";
+    text << "<tr><td>Red:</td><td>" << (unsigned)(r >> 3) << "</td></tr>";
+    text << "<tr><td>Green:</td><td>" << (unsigned)(g >> 3) << "</td></tr>";
+    text << "<tr><td>Blue:</td><td>" << (unsigned)(b >> 3) << "</td></tr>";
+    text << "</table>";
+  }
+  colorInfo->setText(text);
 }

--- a/bsnes/ui-qt/debugger/ppu/cgram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-viewer.moc.hpp
@@ -2,28 +2,22 @@ class CgramViewer : public Window {
   Q_OBJECT
 
 public:
-  QHBoxLayout *layout;
-  struct Canvas : public QWidget {
-    QImage *image;
-    void mousePressEvent(QMouseEvent*);
-    void paintEvent(QPaintEvent*);
-    Canvas();
-  } *canvas;
-  QVBoxLayout *controlLayout;
-  QCheckBox *autoUpdateBox;
-  QPushButton *refreshButton;
-  QLabel *colorInfo;
-
-  void setSelection(unsigned);
-  void autoUpdate();
   CgramViewer();
+
+  void autoUpdate();
 
 public slots:
   void show();
   void refresh();
 
 private:
-  unsigned currentSelection;
+  QHBoxLayout *layout;
+  QVBoxLayout *controlLayout;
+  QCheckBox *autoUpdateBox;
+  QPushButton *refreshButton;
+
+  CgramWidget *cgramWidget;
+  QLabel *colorInfo;
 };
 
 extern CgramViewer *cgramViewer;

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -1,0 +1,124 @@
+#include "cgram-widget.moc"
+
+CgramWidget::CgramWidget() {
+  image = new QImage(16, 16, QImage::Format_RGB32);
+  image->fill(0x000000);
+
+  selected = -1;
+  setScale(16);
+  setPaletteBpp(0);
+}
+
+void CgramWidget::setScale(unsigned s) {
+  scale = s;
+
+  setFixedSize(16 * scale, 16 * scale);
+}
+
+void CgramWidget::setPaletteBpp(unsigned bpp) {
+  if(bpp > 8) bpp == 0;
+
+  unsigned nColors = 1 << bpp;
+
+  selectedMask = 0xff - nColors + 1;
+  selectedWidth = (nColors - 1) % 16 + 1;
+  selectedHeight = (nColors - 1) / 16 + 1;
+
+  selectedChanged();
+
+  update();
+}
+
+bool CgramWidget::hasSelected() const {
+  return selected >= 0 && selected < 256;
+}
+
+unsigned CgramWidget::selectedColor() const {
+  return selected & 0xff;
+}
+
+unsigned CgramWidget::selectedPalette() const {
+  return selected & selectedMask;
+}
+
+void CgramWidget::selectNone() {
+  setSelected(-1);
+}
+
+void CgramWidget::setSelected(int s) {
+  if (s != selected) {
+    if (s < 0 || s > 255) s = -1;
+
+    selected = s;
+    selectedChanged();
+  }
+}
+
+void CgramWidget::paintEvent(QPaintEvent*) {
+  QPainter painter(this);
+  painter.setRenderHints(0);
+  painter.scale(scale, scale);
+  painter.drawImage(0, 0, *image);
+
+  if(selected >= 0 && selected < 256) {
+    const static QPen white(Qt::white, 1, Qt::SolidLine);
+    const static QPen black(Qt::black, 1, Qt::DashLine);
+
+    painter.resetTransform();
+
+    int s = selected & selectedMask;
+    int x = (s % 16) * scale;
+    int y = (s / 16) * scale;
+    int w = selectedWidth * scale - 1;
+    int h = selectedHeight * scale - 1;
+
+    painter.setPen(white);
+    painter.drawRect(x, y, w, h);
+
+    painter.setPen(black);
+    painter.drawRect(x, y, w, h);
+  }
+}
+
+void CgramWidget::mousePressEvent(QMouseEvent *event) {
+  int x = event->x() / scale;
+  int y = event->y() / scale;
+
+  if (x >= 0 && x < 16 && y >= 0 && y < 16) {
+    setSelected(y * 16 + x);
+  } else {
+    setSelected(-1);
+  }
+}
+
+void CgramWidget::refresh() {
+  if(SNES::cartridge.loaded() == false) {
+    setSelected(-1);
+    image->fill(0x000000);
+    update();
+    return;
+  }
+
+  uint32_t *buffer = (uint32_t*)image->bits();
+
+  for(unsigned i = 0; i < 256; i++) {
+    buffer[i] = rgbFromCgram(i);
+  }
+
+  update();
+}
+
+uint32_t rgbFromCgram(unsigned i) {
+  uint16_t color = SNES::memory::cgram[i * 2 + 0];
+  color |= SNES::memory::cgram[i * 2 + 1] << 8;
+
+  uint8_t r = (color >>  0) & 31;
+  uint8_t g = (color >>  5) & 31;
+  uint8_t b = (color >> 10) & 31;
+
+  r = (r << 3) | (r >> 2);
+  g = (g << 3) | (g >> 2);
+  b = (b << 3) | (b >> 2);
+
+  return (r << 16) | (g << 8) | (b << 0);
+}

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
@@ -1,0 +1,37 @@
+class CgramWidget : public QWidget {
+  Q_OBJECT
+
+public:
+  CgramWidget();
+  void paintEvent(QPaintEvent*);
+  void mousePressEvent(QMouseEvent*);
+
+  void setScale(unsigned);
+
+  void setPaletteBpp(unsigned);
+
+  bool hasSelected() const;
+  unsigned selectedPalette() const;
+
+  unsigned selectedColor() const;
+
+  void selectNone();
+  void setSelected(int);
+
+public slots:
+  void refresh();
+
+signals:
+  void selectedChanged();
+
+private:
+  QImage *image;
+  int selected;
+
+  unsigned scale;
+  unsigned selectedMask;
+  unsigned selectedWidth;
+  unsigned selectedHeight;
+};
+
+uint32_t rgbFromCgram(unsigned);

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -126,7 +126,14 @@ void VramViewer::zoomChanged(int index) {
   if(z == 0) z = 1;
 
   canvas->setZoom(z);
-  scrollArea->setMinimumWidth(canvas->width() + scrollArea->verticalScrollBar()->width() * 2);
+
+  int scrollWidth = canvas->width() + scrollArea->verticalScrollBar()->width() * 2;
+  scrollArea->setMinimumWidth(scrollWidth);
+
+  int mainWidth = scrollWidth + sidebarLayout->minimumSize().width();
+  int controlWidth = controlLayout->minimumSize().width();
+
+  setFixedWidth(max(mainWidth, controlWidth) + Style::WidgetSpacing * 3);
 }
 
 void VramViewer::gotoAddress(unsigned vram_addr) {

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -8,7 +8,7 @@ VramViewer::VramViewer() {
   application.windowList.append(this);
 
   layout = new QVBoxLayout;
-  layout->setSizeConstraint(QLayout::SetFixedSize);
+  layout->setSizeConstraint(QLayout::SetMinimumSize);
   layout->setAlignment(Qt::AlignCenter);
   layout->setMargin(Style::WindowMargin);
   layout->setSpacing(Style::WidgetSpacing);
@@ -31,6 +31,14 @@ VramViewer::VramViewer() {
   depthMode7 = new QRadioButton("Mode 7");
   controlLayout->addWidget(depthMode7);
 
+  zoom = new QComboBox;
+  zoom->addItem("1x", QVariant(1));
+  zoom->addItem("3x", QVariant(3));
+  zoom->addItem("5x", QVariant(5));
+  zoom->addItem("7x", QVariant(7));
+  zoom->addItem("9x", QVariant(9));
+  controlLayout->addWidget(zoom);
+
   autoUpdateBox = new QCheckBox("Auto update");
   controlLayout->addWidget(autoUpdateBox);
 
@@ -40,6 +48,7 @@ VramViewer::VramViewer() {
   scrollArea = new QScrollArea;
   scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  scrollArea->setMinimumHeight(300);
   layout->addWidget(scrollArea);
 
   canvas = new VramCanvas;
@@ -51,12 +60,16 @@ VramViewer::VramViewer() {
   canvas->setDepth2bpp();
   depth2bpp->setChecked(true);
 
+  zoom->setCurrentIndex(1);
+  zoomChanged(1);
+
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
+  connect(zoom,       SIGNAL(currentIndexChanged(int)), this, SLOT(zoomChanged(int)));
   connect(depth2bpp,  SIGNAL(pressed()), canvas, SLOT(setDepth2bpp()));
   connect(depth4bpp,  SIGNAL(pressed()), canvas, SLOT(setDepth4bpp()));
   connect(depth8bpp,  SIGNAL(pressed()), canvas, SLOT(setDepth8bpp()));
   connect(depthMode7, SIGNAL(pressed()), canvas, SLOT(setDepthMode7()));
-  connect(canvas, SIGNAL(infoChanged(unsigned)), this, SLOT(displayInfo(unsigned)));
+  connect(canvas,     SIGNAL(infoChanged(unsigned)), this, SLOT(displayInfo(unsigned)));
 }
 
 void VramViewer::autoUpdate() {
@@ -72,10 +85,19 @@ void VramViewer::refresh() {
   canvas->refresh();
 }
 
+void VramViewer::zoomChanged(int index) {
+  unsigned z = zoom->itemData(index).toUInt();
+  if(z == 0) z = 1;
+
+  canvas->setZoom(z);
+  scrollArea->setMinimumWidth(canvas->width() + scrollArea->verticalScrollBar()->width() * 2);
+}
+
 VramCanvas::VramCanvas() {
   image = new QImage(128, 2048, QImage::Format_RGB32);
   image->fill(0x800000);
 
+  zoom = 1;
   setDepth2bpp();
 }
 
@@ -188,13 +210,30 @@ void VramCanvas::refreshMode7(const uint8_t *source) {
   }
 }
 
-void VramCanvas::setDepth2bpp()  { bpp = 2; setFixedSize(128, 2048); refresh(); }
-void VramCanvas::setDepth4bpp()  { bpp = 4; setFixedSize(128, 1024); refresh(); }
-void VramCanvas::setDepth8bpp()  { bpp = 8; setFixedSize(128, 512);  refresh(); }
-void VramCanvas::setDepthMode7() { bpp = 7; setFixedSize(128, 128);  refresh(); }
+void VramCanvas::setDepth2bpp()  { bpp = 2; updateWidgetSize(); }
+void VramCanvas::setDepth4bpp()  { bpp = 4; updateWidgetSize(); }
+void VramCanvas::setDepth8bpp()  { bpp = 8; updateWidgetSize(); }
+void VramCanvas::setDepthMode7() { bpp = 7; updateWidgetSize(); }
+
+void VramCanvas::setZoom(unsigned newZoom) {
+    zoom = newZoom;
+
+    updateWidgetSize();
+}
+
+void VramCanvas::updateWidgetSize() {
+    if (bpp == 2) setFixedSize(128 * zoom, 2048 * zoom);
+    if (bpp == 4) setFixedSize(128 * zoom, 1024 * zoom);
+    if (bpp == 8) setFixedSize(128 * zoom,  512 * zoom);
+    if (bpp == 7) setFixedSize(128 * zoom,  128 * zoom);
+
+    refresh();
+}
 
 void VramCanvas::paintEvent(QPaintEvent*) {
   QPainter painter(this);
+  painter.setRenderHints(0);
+  painter.scale(zoom, zoom);
   painter.drawImage(0, 0, *image);
 }
 
@@ -210,8 +249,8 @@ void VramViewer::displayInfo(unsigned vram_addr) {
 
 void VramCanvas::mousePressEvent(QMouseEvent* event) {
   if (event->button() == Qt::LeftButton) {
-	  unsigned column = event->x() / 8;
-	  unsigned row = event->y() / 8;
+	  unsigned column = event->x() / 8 / zoom;
+	  unsigned row = event->y() / 8 / zoom;
 	  unsigned tile_num = (row * 16) + column;
 	  unsigned vram_addr = (tile_num * bpp * 8);
 	  emit infoChanged(vram_addr);

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -58,14 +58,12 @@ VramViewer::VramViewer() {
   baseAddrLabel = new QLabel("Base Tile Addresses:");
   sidebarLayout->addWidget(baseAddrLabel);
 
-  //TODO: Properly expose these values to the debugger
-  //TODO: Add second sprite table address
-
   vramAddrItems[0] = new VramAddrItem("BG1:", "BG1 Name Base Address");
   vramAddrItems[1] = new VramAddrItem("BG2:", "BG2 Name Base Address");
   vramAddrItems[2] = new VramAddrItem("BG3:", "BG3 Name Base Address");
   vramAddrItems[3] = new VramAddrItem("BG4:", "BG4 Name Base Address");
-  vramAddrItems[4] = new VramAddrItem("OAM:", "OAM Name Base Address");
+  vramAddrItems[4] = new VramAddrItem("OAM1:", "OAM Name Base Address");
+  vramAddrItems[5] = new VramAddrItem("OAM2:", "OAM Second Name Table Address");
 
   for (unsigned i = 0; i < N_MAP_ITEMS; i++) {
     sidebarLayout->addWidget(vramAddrItems[i]);

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -1,12 +1,27 @@
 struct VramCanvas : public QWidget {
 	Q_OBJECT
 public:
-    QImage *image;
-    void paintEvent(QPaintEvent*);
-    void mousePressEvent(QMouseEvent*);
-    VramCanvas();
+  QImage *image;
+  void paintEvent(QPaintEvent*);
+  void mousePressEvent(QMouseEvent*);
+  VramCanvas();
+
+public slots:
+  void refresh();
+  void setDepth2bpp();
+  void setDepth4bpp();
+  void setDepth8bpp();
+  void setDepthMode7();
+
 signals:
-	void infoChanged(unsigned);
+	void infoChanged(unsigned vram_addr);
+
+private:
+  unsigned bpp;
+  void refresh2bpp(const uint8_t*);
+  void refresh4bpp(const uint8_t*);
+  void refresh8bpp(const uint8_t*);
+  void refreshMode7(const uint8_t*);
 };
 
 class VramViewer : public Window {
@@ -23,6 +38,7 @@ public:
   QPushButton *refreshButton;
   QLabel *vramInfo;
   VramCanvas *canvas;
+  QScrollArea *scrollArea;
 
   void autoUpdate();
   VramViewer();
@@ -30,18 +46,7 @@ public:
 public slots:
   void show();
   void refresh();
-  void setDepth2bpp();
-  void setDepth4bpp();
-  void setDepth8bpp();
-  void setDepthMode7();
-  void displayInfo(unsigned);
-
-private:
-  unsigned bpp;
-  void refresh2bpp(const uint8_t*, uint32_t*);
-  void refresh4bpp(const uint8_t*, uint32_t*);
-  void refresh8bpp(const uint8_t*, uint32_t*);
-  void refreshMode7(const uint8_t*, uint32_t*);
+  void displayInfo(unsigned vram_addr);
 };
 
 extern VramViewer *vramViewer;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -6,6 +6,8 @@ public:
   void mousePressEvent(QMouseEvent*);
   VramCanvas();
 
+  int tileYPos(unsigned vram_addr);
+
 public slots:
   void refresh();
   void setDepth2bpp();
@@ -27,12 +29,42 @@ private:
   void refreshMode7(const uint8_t*);
 };
 
+class VramAddrItem : public QWidget {
+  Q_OBJECT
+
+public:
+  VramAddrItem(const QString& text, const string& property);
+
+public slots:
+  void refresh();
+
+signals:
+  void gotoPressed(unsigned);
+
+private slots:
+  void onGotoPressed();
+
+private:
+  unsigned propertyId;
+
+  QHBoxLayout *layout;
+
+  QLabel *label;
+  QLineEdit *address;
+  QToolButton *gotoButton;
+};
+
 class VramViewer : public Window {
   Q_OBJECT
+
+  const static unsigned N_MAP_ITEMS = 5;
 
 public:
   QVBoxLayout *layout;
   QHBoxLayout *controlLayout;
+  QHBoxLayout *mainLayout;
+  QVBoxLayout *sidebarLayout;
+
   QRadioButton *depth2bpp;
   QRadioButton *depth4bpp;
   QRadioButton *depth8bpp;
@@ -41,6 +73,10 @@ public:
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
   QLabel *vramInfo;
+
+  QLabel *baseAddrLabel;
+  VramAddrItem *vramAddrItems[N_MAP_ITEMS];
+
   VramCanvas *canvas;
   QScrollArea *scrollArea;
 
@@ -51,6 +87,7 @@ public slots:
   void show();
   void refresh();
   void zoomChanged(int);
+  void gotoAddress(unsigned vram_addr);
   void displayInfo(unsigned vram_addr);
 };
 

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -12,12 +12,15 @@ public slots:
   void setDepth4bpp();
   void setDepth8bpp();
   void setDepthMode7();
+  void setZoom(unsigned);
+  void updateWidgetSize();
 
 signals:
-	void infoChanged(unsigned vram_addr);
+  void infoChanged(unsigned vram_addr);
 
 private:
   unsigned bpp;
+  unsigned zoom;
   void refresh2bpp(const uint8_t*);
   void refresh4bpp(const uint8_t*);
   void refresh8bpp(const uint8_t*);
@@ -34,6 +37,7 @@ public:
   QRadioButton *depth4bpp;
   QRadioButton *depth8bpp;
   QRadioButton *depthMode7;
+  QComboBox *zoom;
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
   QLabel *vramInfo;
@@ -46,6 +50,7 @@ public:
 public slots:
   void show();
   void refresh();
+  void zoomChanged(int);
   void displayInfo(unsigned vram_addr);
 };
 

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -57,7 +57,7 @@ private:
 class VramViewer : public Window {
   Q_OBJECT
 
-  const static unsigned N_MAP_ITEMS = 5;
+  const static unsigned N_MAP_ITEMS = 6;
 
 public:
   QVBoxLayout *layout;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -1,10 +1,10 @@
 struct VramCanvas : public QWidget {
 	Q_OBJECT
+
 public:
-  QImage *image;
+  VramCanvas();
   void paintEvent(QPaintEvent*);
   void mousePressEvent(QMouseEvent*);
-  VramCanvas();
 
   int tileYPos(unsigned vram_addr);
 
@@ -14,6 +14,8 @@ public slots:
   void setDepth4bpp();
   void setDepth8bpp();
   void setDepthMode7();
+  void setUseCgram(bool);
+  void setSelectedColor(int);
   void setZoom(unsigned);
   void updateWidgetSize();
 
@@ -21,12 +23,22 @@ signals:
   void infoChanged(unsigned vram_addr);
 
 private:
-  unsigned bpp;
-  unsigned zoom;
+  void buildDefaultPalette();
+  void buildCgramPalette();
+
   void refresh2bpp(const uint8_t*);
   void refresh4bpp(const uint8_t*);
   void refresh8bpp(const uint8_t*);
   void refreshMode7(const uint8_t*);
+
+private:
+  QImage *image;
+  unsigned bpp;
+  unsigned zoom;
+  unsigned selectedColor;
+  bool useCgram;
+
+  uint32_t palette[256];
 };
 
 class VramAddrItem : public QWidget {
@@ -76,6 +88,9 @@ public:
 
   QLabel *baseAddrLabel;
   VramAddrItem *vramAddrItems[N_MAP_ITEMS];
+
+  QCheckBox *useCgram;
+  QSpinBox *selectedColor;
 
   VramCanvas *canvas;
   QScrollArea *scrollArea;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -15,7 +15,7 @@ public slots:
   void setDepth8bpp();
   void setDepthMode7();
   void setUseCgram(bool);
-  void setSelectedColor(int);
+  void setSelectedColor(unsigned);
   void setZoom(unsigned);
   void updateWidgetSize();
 
@@ -90,9 +90,9 @@ public:
   VramAddrItem *vramAddrItems[N_MAP_ITEMS];
 
   QCheckBox *useCgram;
-  QSpinBox *selectedColor;
+  CgramWidget *cgramWidget;
 
-  VramCanvas *canvas;
+  VramCanvas *vramCanvas;
   QScrollArea *scrollArea;
 
   void autoUpdate();
@@ -104,6 +104,10 @@ public slots:
   void zoomChanged(int);
   void gotoAddress(unsigned vram_addr);
   void displayInfo(unsigned vram_addr);
+
+  void onDepthChanged();
+  void onUseCgramPressed();
+  void onCgramSelectedChanged();
 };
 
 extern VramViewer *vramViewer;

--- a/bsnes/ui-qt/debugger/tools/breakpoint.cpp
+++ b/bsnes/ui-qt/debugger/tools/breakpoint.cpp
@@ -92,6 +92,32 @@ void BreakpointItem::toggle() {
   }
 }
 
+void BreakpointItem::setBreakpoint(string addrStr, string mode, string sourceStr) {
+  if (addrStr == "" || mode == "") return;
+
+  sourceStr.lower();
+  if(sourceStr == "cpu")        { source->setCurrentIndex(0); }
+  else if(sourceStr == "smp")   { source->setCurrentIndex(1); }
+  else if(sourceStr == "vram")  { source->setCurrentIndex(2); }
+  else if(sourceStr == "oam")   { source->setCurrentIndex(3); }
+  else if(sourceStr == "cgram") { source->setCurrentIndex(4); }
+  else if(sourceStr == "sa1")   { source->setCurrentIndex(5); }
+  else if(sourceStr == "sfx")   { source->setCurrentIndex(6); }
+  else { return; }
+
+  mode.lower();
+  if(mode.position("r")) { mode_r->setChecked(true); }
+  if(mode.position("w")) { mode_w->setChecked(true); }
+  if(mode.position("x")) { mode_x->setChecked(true); }
+
+  lstring addresses;
+  addresses.split<2>("-", addrStr);
+  addr->setText(addresses[0]);
+  if (addresses.size() >= 2) { addr_end->setText(addresses[1]); }
+
+  toggle();
+}
+
 BreakpointEditor::BreakpointEditor() {
   setObjectName("breakpoint-editor");
   setWindowTitle("Breakpoint Editor");
@@ -116,4 +142,13 @@ BreakpointEditor::BreakpointEditor() {
 
 void BreakpointEditor::toggle() {
   SNES::debugger.break_on_wdm = breakOnWDM->isChecked();
+}
+
+void BreakpointEditor::addBreakpoint(const string& addr, const string& mode, const string& source) {
+  for(unsigned n = 0; n < SNES::Debugger::Breakpoints; n++) {
+    if(breakpoint[n]->addr->text().isEmpty()) {
+      breakpoint[n]->setBreakpoint(addr, mode, source);
+      return;
+    }
+  }
 }

--- a/bsnes/ui-qt/debugger/tools/breakpoint.moc.hpp
+++ b/bsnes/ui-qt/debugger/tools/breakpoint.moc.hpp
@@ -23,6 +23,8 @@ public:
   QComboBox *source;
   BreakpointItem(unsigned id);
 
+  void setBreakpoint(string addr, string mode, string source);
+
 public slots:
   void init();
   void toggle();
@@ -40,7 +42,9 @@ public:
   QCheckBox *breakOnWDM;
 
   BreakpointEditor();
-  
+
+  void addBreakpoint(const string& addr, const string& mode, const string& source);
+
 public slots:
   void toggle();
 };

--- a/bsnes/ui-qt/debugger/tools/properties.cpp
+++ b/bsnes/ui-qt/debugger/tools/properties.cpp
@@ -33,11 +33,15 @@ PropertiesWidget::PropertiesWidget(SNES::ChipDebugger &object) : object(object) 
   list->setSortingEnabled(false);
   layout->addWidget(list);
 
+  bool indent = false;
   unsigned counter = 0;
   while(true) {
     string name, value;
     bool result = object.property(counter, name, value);
     if(result == false) break;
+
+    if(value == "") indent = true;
+    if(value != "" && indent) name = string("     ", name);
 
     QTreeWidgetItem *item = new QTreeWidgetItem(list);
     item->setData(0, Qt::UserRole, QVariant(counter++));

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -48,6 +48,7 @@ using namespace ruby;
   #include "debugger/tools/memory.moc.hpp"
   #include "debugger/tools/properties.moc.hpp"
 
+  #include "debugger/ppu/cgram-widget.moc.hpp"
   #include "debugger/ppu/vram-viewer.moc.hpp"
   #include "debugger/ppu/oam-viewer.moc.hpp"
   #include "debugger/ppu/cgram-viewer.moc.hpp"


### PR DESCRIPTION
This request adds the following features to the bsnes-plus debugger:

 * Break/Run button now has a constant size, preventing the debugger textbox size from changing when stepping through code.
 * Improved Vram Viewer:
  * Tileset width is now 16 tiles to match the SNES internals
  * Added zoom
  * Added a TextBox to enter in a Vram address and scroll to it
  * Added a series of buttons to autoscroll to the BG/OBJ tile address
  * Select tileset palette from cgram
 * Added "OAM Second Name Table Address" property
 * Indent the register property names in the Properties Table, improving readability.
 * Command line arguments:
  * --show-debugger - opens the debugger window
  * --breakpoint - adds a breakpoint to the debugger

All of these features have been things that I wished bsnes had last year when coding Super Nintendo demos but never had the time to implement.

The code has been tested and confirmed working on both ArchLinux and a Windows 7 VM.

**EDIT:** Also added the `obj` and `out` directories to `.gitignore` after accidentally pushing my bsnes binary to github once.