### PR TITLE
VRAM Debugger: Pixel perfect image interpolation

### DIFF
--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -57,8 +57,7 @@ void CgramWidget::setSelected(int s) {
 void CgramWidget::paintEvent(QPaintEvent*) {
   QPainter painter(this);
   painter.setRenderHints(0);
-  painter.scale(scale, scale);
-  painter.drawImage(0, 0, *image);
+  painter.drawImage(0, 0, image->scaled(image->width() * scale, image->height() * scale, Qt::IgnoreAspectRatio, Qt::FastTransformation));
 
   if(selected >= 0 && selected < 256) {
     const static QPen white(Qt::white, 1, Qt::SolidLine);

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -16,7 +16,7 @@ void CgramWidget::setScale(unsigned s) {
 }
 
 void CgramWidget::setPaletteBpp(unsigned bpp) {
-  if(bpp > 8) bpp == 0;
+  if(bpp > 8) bpp = 0;
 
   unsigned nColors = 1 << bpp;
 

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -365,8 +365,7 @@ void VramCanvas::updateWidgetSize() {
 void VramCanvas::paintEvent(QPaintEvent*) {
   QPainter painter(this);
   painter.setRenderHints(0);
-  painter.scale(zoom, zoom);
-  painter.drawImage(0, 0, *image);
+  painter.drawImage(0, 0, image->scaled(image->width() * zoom, image->height() * zoom, Qt::IgnoreAspectRatio, Qt::FastTransformation));
 }
 
 void VramViewer::displayInfo(unsigned vram_addr) {


### PR DESCRIPTION
Changed image draw calls to use nearest neighbour interpolation.
Also fixed a typo: `if(bpp > 8) bpp == 0;`.