### PR TITLE
Fix BG screen sizes in Properties

### DIFF
--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
@@ -84,27 +84,28 @@ bool PPUDebugger::property(unsigned id, string &name, string &value) {
   item("BG3 Mosaic Enable", regs.mosaic_enabled[BG3]);
   item("BG4 Mosaic Enable", regs.mosaic_enabled[BG4]);
 
-  static char screen_size[4][8] = { "32x32", "32x64", "64x32", "64x64" };
+  // Width x Height
+  static char screen_size[4][8] = { "32x32", "64x32", "32x64", "64x64" };
 
   //$2107
   item("$2107", "");
   item("BG1 Screen Address", string("0x", hex<4>(regs.bg_scaddr[BG1])));
-  item("BG1 Screen Size", screen_size[regs.bg_scsize[BG1]]);
+  item("BG1 Screen Size", screen_size[regs.bg_scsize[BG1] & 3]);
 
   //$2108
   item("$2108", "");
   item("BG2 Screen Address", string("0x", hex<4>(regs.bg_scaddr[BG2])));
-  item("BG2 Screen Size", screen_size[regs.bg_scsize[BG2]]);
+  item("BG2 Screen Size", screen_size[regs.bg_scsize[BG2] & 3]);
 
   //$2109
   item("$2109", "");
   item("BG3 Screen Address", string("0x", hex<4>(regs.bg_scaddr[BG3])));
-  item("BG3 Screen Size", screen_size[regs.bg_scsize[BG3]]);
+  item("BG3 Screen Size", screen_size[regs.bg_scsize[BG3] & 3]);
 
   //$210a
   item("$210a", "");
   item("BG4 Screen Address", string("0x", hex<4>(regs.bg_scaddr[BG4])));
-  item("BG4 Screen Size", screen_size[regs.bg_scsize[BG4]]);
+  item("BG4 Screen Size", screen_size[regs.bg_scsize[BG4] & 3]);
 
   //$210b
   item("$210b", "");

--- a/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
@@ -80,7 +80,8 @@ bool PPUDebugger::property(unsigned id, string &name, string &value) {
   item("BG3 Mosaic Size", bg3.regs.mosaic);
   item("BG4 Mosaic Size", bg4.regs.mosaic);
 
-  static char screen_size[4][8] = { "32x32", "32x64", "64x32", "64x64" };
+  // Width x Height
+  static char screen_size[4][8] = { "32x32", "64x32", "32x64", "64x64" };
 
   //$2107
   item("$2107", "");

--- a/bsnes/snes/ppu/debugger/debugger.cpp
+++ b/bsnes/snes/ppu/debugger/debugger.cpp
@@ -80,7 +80,8 @@ bool PPUDebugger::property(unsigned id, string &name, string &value) {
   item("BG3 Mosaic Size", bg3.regs.mosaic);
   item("BG4 Mosaic Size", bg4.regs.mosaic);
 
-  static char screen_size[4][8] = { "32x32", "32x64", "64x32", "64x64" };
+  // Width x Height
+  static char screen_size[4][8] = { "32x32", "64x32", "32x64", "64x64" };
 
   //$2107
   item("$2107", "");


### PR DESCRIPTION
Currently 32x64 is depicted as 64x32, and vice versa.  Per offical documentation -- $2107-210a, bits 1-0, define screen size/layout:

%00 (0) = 32x32 (one screen)
%01 (1) = 64x32 (2 screens "wide", a.k.a. vertical mirroring)
%10 (2) = 32x64 (2 screens "tall", a.k.a. horizontal mirroring)
%11 (3) = 64x64 (4 screens (2 wide, 2 tall))

While I'm here: modify ppu-compatibility/debugger/debugger.cpp to also mask off all bits other than 1-0.