### PR TITLE
More updates to the debugger

### DIFF
--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -55,8 +55,19 @@ OamViewer::OamViewer() {
   list->setAllColumnsShowFocus(true);
   list->setAlternatingRowColors(true);
   list->setRootIsDecorated(false);
+  list->setUniformRowHeights(true);
   list->setSortingEnabled(false);
   layout->addWidget(list);
+
+  unsigned dw = list->fontMetrics().width('0');
+  list->setColumnWidth(0, dw * 4);
+  list->setColumnWidth(1, dw * 8);
+  list->setColumnWidth(2, dw * 6);
+  list->setColumnWidth(3, dw * 6);
+  list->setColumnWidth(4, dw * 6);
+  list->setColumnWidth(5, dw * 6);
+  list->setColumnWidth(6, dw * 6);
+  list->setColumnWidth(7, dw * 6);
 
   for(unsigned i = 0; i < 128; i++) {
     QTreeWidgetItem *item = new QTreeWidgetItem(list);
@@ -121,8 +132,6 @@ void OamViewer::refresh() {
     item->setText(6, string() << obj.palette);
     item->setText(7, flags);
   }
-
-  for(unsigned i = 0; i <= 7; i++) list->resizeColumnToContents(i);
 
   canvas->refresh();
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -1,66 +1,40 @@
 #include "oam-viewer.moc"
 OamViewer *oamViewer;
 
-void OamViewer::show() {
-  Window::show();
-  refresh();
-}
+OamObject OamObject::getObject(unsigned i) {
+  OamObject obj;
 
-void OamViewer::refresh() {
-  canvas->image->fill(0x000000);
+  uint8_t d0 = SNES::memory::oam[(i << 2) + 0];
+  uint8_t d1 = SNES::memory::oam[(i << 2) + 1];
+  uint8_t d2 = SNES::memory::oam[(i << 2) + 2];
+  uint8_t d3 = SNES::memory::oam[(i << 2) + 3];
+  uint8_t d4 = SNES::memory::oam[512 + (i >> 2)];
+  bool x    = d4 & (1 << ((i & 3) << 1));
+  bool size = d4 & (2 << ((i & 3) << 1));
 
-  QList<QTreeWidgetItem*> items = list->findItems("", Qt::MatchContains);
-  for(unsigned v = 0; v < items.count(); v++) {
-    QTreeWidgetItem *item = items[v];
-    unsigned i = item->data(0, Qt::UserRole).toUInt();
-
-    uint8_t d0 = SNES::memory::oam[(i << 2) + 0];
-    uint8_t d1 = SNES::memory::oam[(i << 2) + 1];
-    uint8_t d2 = SNES::memory::oam[(i << 2) + 2];
-    uint8_t d3 = SNES::memory::oam[(i << 2) + 3];
-    uint8_t d4 = SNES::memory::oam[512 + (i >> 2)];
-    bool x    = d4 & (1 << ((i & 3) << 1));
-    bool size = d4 & (2 << ((i & 3) << 1));
-
-    //TODO: create method to expose ChipDebugger::property values by name
-    unsigned width, height;
-    switch(SNES::ppu.oam_base_size()) { default:
-      case 0: width = !size ?  8 : 16; height = !size ?  8 : 16; break;
-      case 1: width = !size ?  8 : 32; height = !size ?  8 : 32; break;
-      case 2: width = !size ?  8 : 64; height = !size ?  8 : 64; break;
-      case 3: width = !size ? 16 : 32; height = !size ? 16 : 32; break;
-      case 4: width = !size ? 16 : 64; height = !size ? 16 : 64; break;
-      case 5: width = !size ? 32 : 64; height = !size ? 32 : 64; break;
-      case 6: width = !size ? 16 : 32; height = !size ? 32 : 64; break;
-      case 7: width = !size ? 16 : 32; height = !size ? 32 : 32; break;
-    }
-
-    signed xpos = (x << 8) + d0;
-    if(xpos > 256) xpos = sclip<9>(xpos);
-    unsigned ypos = d1;
-    unsigned character = d2;
-    unsigned priority = (d3 >> 4) & 3;
-    unsigned palette = (d3 >> 1) & 7;
-    string flags;
-    if(d3 & 0x80) flags << "V";
-    if(d3 & 0x40) flags << "H";
-    if(d3 & 0x01) flags << "N";
-
-    item->setText(1, string() << width << "x" << height);
-    item->setText(2, string() << xpos);
-    item->setText(3, string() << ypos);
-    item->setText(4, string() << character);
-    item->setText(5, string() << priority);
-    item->setText(6, string() << palette);
-    item->setText(7, flags);
+  switch(SNES::ppu.oam_base_size()) { default:
+    case 0: obj.width = !size ?  8 : 16; obj.height = !size ?  8 : 16; break;
+    case 1: obj.width = !size ?  8 : 32; obj.height = !size ?  8 : 32; break;
+    case 2: obj.width = !size ?  8 : 64; obj.height = !size ?  8 : 64; break;
+    case 3: obj.width = !size ? 16 : 32; obj.height = !size ? 16 : 32; break;
+    case 4: obj.width = !size ? 16 : 64; obj.height = !size ? 16 : 64; break;
+    case 5: obj.width = !size ? 32 : 64; obj.height = !size ? 32 : 64; break;
+    case 6: obj.width = !size ? 16 : 32; obj.height = !size ? 32 : 64; break;
+    case 7: obj.width = !size ? 16 : 32; obj.height = !size ? 32 : 32; break;
   }
 
-  for(unsigned i = 0; i <= 7; i++) list->resizeColumnToContents(i);
-  canvas->update();
-}
+  obj.xpos = (x << 8) + d0;
+  if(obj.xpos > 256) obj.xpos = sclip<9>(obj.xpos);
 
-void OamViewer::autoUpdate() {
-  if(autoUpdateBox->isChecked()) refresh();
+  obj.ypos = d1;
+  obj.character = d2;
+  obj.priority = (d3 >> 4) & 3;
+  obj.palette = (d3 >> 1) & 7;
+  obj.hFlip = d3 & 0x80;
+  obj.vFlip = d3 & 0x40;
+  obj.table = d3 & 0x01;
+
+  return obj;
 }
 
 OamViewer::OamViewer() {
@@ -103,8 +77,8 @@ OamViewer::OamViewer() {
   controlLayout->setSpacing(0);
   layout->addLayout(controlLayout);
 
-  canvas = new Canvas;
-  canvas->setFixedSize(128, 128);
+
+  canvas = new OamCanvas;
   controlLayout->addWidget(canvas);
 
   autoUpdateBox = new QCheckBox("Auto update");
@@ -114,14 +88,149 @@ OamViewer::OamViewer() {
   controlLayout->addWidget(refreshButton);
 
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
+  connect(list, SIGNAL(itemSelectionChanged()), this, SLOT(onSelectedChanged()));
 }
 
-void OamViewer::Canvas::paintEvent(QPaintEvent*) {
-  QPainter painter(this);
-  painter.drawImage(0, 0, *image);
+void OamViewer::show() {
+  Window::show();
+  refresh();
 }
 
-OamViewer::Canvas::Canvas() {
-  image = new QImage(128, 128, QImage::Format_RGB32);
-  image->fill(0x000000);
+void OamViewer::autoUpdate() {
+  if(autoUpdateBox->isChecked()) refresh();
+}
+
+void OamViewer::refresh() {
+  QList<QTreeWidgetItem*> items = list->findItems("", Qt::MatchContains);
+  for(unsigned v = 0; v < items.count(); v++) {
+    QTreeWidgetItem *item = items[v];
+    unsigned i = item->data(0, Qt::UserRole).toUInt();
+
+    OamObject obj = OamObject::getObject(i);
+
+    string flags;
+    if(obj.hFlip) flags << "V";
+    if(obj.vFlip) flags << "H";
+    if(obj.table) flags << "N";
+
+    item->setText(1, string() << obj.width << "x" << obj.height);
+    item->setText(2, string() << obj.xpos);
+    item->setText(3, string() << obj.ypos);
+    item->setText(4, string() << obj.character);
+    item->setText(5, string() << obj.priority);
+    item->setText(6, string() << obj.palette);
+    item->setText(7, flags);
+  }
+
+  for(unsigned i = 0; i <= 7; i++) list->resizeColumnToContents(i);
+
+  canvas->refresh();
+}
+
+void OamViewer::onSelectedChanged() {
+  QList<QTreeWidgetItem *> sel = list->selectedItems();
+
+  int i = -1;
+  if(!sel.empty()) i = sel.at(0)->data(0, Qt::UserRole).toUInt();
+
+  canvas->setSelected(i);
+  refresh();
+}
+
+OamCanvas::OamCanvas() {
+  setFrameStyle(QFrame::Shape::Panel | QFrame::Sunken);
+  setLineWidth(2);
+
+  selected = -1;
+  setScale(2);
+}
+
+void OamCanvas::paintEvent(QPaintEvent*e) {
+  QFrame::paintEvent(e);
+
+  if(!image.isNull()) {
+    QPainter painter(this);
+    painter.setRenderHints(0);
+
+    unsigned x = (width() - image.width()) / 2;
+    unsigned y = (width() - image.height()) / 2;
+    painter.drawImage(x, y, image);
+  }
+}
+
+void OamCanvas::setScale(unsigned z) {
+  imageSize = 64 * z;
+  setFixedSize(imageSize + frameWidth() * 2, imageSize + frameWidth() * 2);
+  refresh();
+}
+
+void OamCanvas::setSelected(int s) {
+  selected = s;
+  refresh();
+}
+
+void OamCanvas::refresh() {
+  if(SNES::cartridge.loaded() && selected >= 0 && selected < 128) {
+    refreshImage(OamObject::getObject(selected));
+  } else {
+    image = QImage();
+  }
+
+  update();
+}
+
+void OamCanvas::refreshImage(const OamObject& obj) {
+  uint32_t palette[16];
+  for(unsigned i = 0; i < 16; i++) {
+    palette[i] = rgbFromCgram(128 + obj.palette * 16 + i);
+  }
+
+  QImage buffer(obj.width, obj.height, QImage::Format_RGB32);
+  const uint8_t *objTileset = SNES::memory::vram.data() + SNES::ppu.oam_tile_addr(obj.table);
+
+  for(unsigned ty = 0; ty < obj.height / 8; ty++) {
+    for(unsigned tx = 0; tx < obj.width / 8; tx++) {
+      unsigned cx = (obj.character + tx) & 0x00f;
+      unsigned cy = (obj.character / 16) + ty;
+      const uint8_t* tile = objTileset + cy * 512 + cx * 32;
+
+      for(unsigned py = 0; py < 8; py++) {
+        uint32_t *dest = ((uint32_t*)buffer.scanLine(ty * 8 + py)) + tx * 8;
+
+        uint8_t d0 = tile[ 0];
+        uint8_t d1 = tile[ 1];
+        uint8_t d2 = tile[16];
+        uint8_t d3 = tile[17];
+        for(unsigned px = 0; px < 8; px++) {
+          uint8_t pixel = 0;
+          pixel |= (d0 & (0x80 >> px)) ? 1 : 0;
+          pixel |= (d1 & (0x80 >> px)) ? 2 : 0;
+          pixel |= (d2 & (0x80 >> px)) ? 4 : 0;
+          pixel |= (d3 & (0x80 >> px)) ? 8 : 0;
+          dest[px] = palette[pixel];
+        }
+        tile += 2;
+      }
+    }
+  }
+
+  int zoom = imageSize / maximumOamBaseSize();
+  int xScale = obj.vFlip ? -zoom : zoom;
+  int yScale = obj.hFlip ? -zoom : zoom;
+
+  image = buffer.transformed(QTransform::fromScale(xScale, yScale), Qt::FastTransformation);
+}
+
+unsigned OamCanvas::maximumOamBaseSize() {
+  switch(SNES::ppu.oam_base_size()) {
+    case 0: return 16;
+    case 1: return 32;
+    case 2: return 64;
+    case 3: return 32;
+    case 4: return 64;
+    case 5: return 64;
+    case 6: return 64;
+    case 7: return 32;
+  }
+  return 16;
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -1,24 +1,60 @@
+struct OamObject {
+  unsigned width;
+  unsigned height;
+  signed   xpos;
+  unsigned ypos;
+  unsigned character;
+  unsigned priority;
+  unsigned palette;
+  bool hFlip;
+  bool vFlip;
+  bool table;
+
+  static OamObject getObject(unsigned);
+};
+
+class OamCanvas : public QFrame {
+  Q_OBJECT
+
+public:
+  OamCanvas();
+  void paintEvent(QPaintEvent*);
+
+public slots:
+  void refresh();
+  void setSelected(int);
+  void setScale(unsigned);
+
+private:
+  void refreshImage(const OamObject& obj);
+  unsigned maximumOamBaseSize();
+
+private:
+  int selected;
+  unsigned imageSize;
+  QImage image;
+};
+
 class OamViewer : public Window {
   Q_OBJECT
 
 public:
-  QHBoxLayout *layout;
-  QTreeWidget *list;
-  QVBoxLayout *controlLayout;
-  struct Canvas : public QWidget {
-    QImage *image;
-    void paintEvent(QPaintEvent*);
-    Canvas();
-  } *canvas;
-  QCheckBox *autoUpdateBox;
-  QPushButton *refreshButton;
-
-  void autoUpdate();
   OamViewer();
+  void autoUpdate();
 
 public slots:
   void show();
   void refresh();
+
+  void onSelectedChanged();
+
+private:
+  QHBoxLayout *layout;
+  QTreeWidget *list;
+  QVBoxLayout *controlLayout;
+  OamCanvas *canvas;
+  QCheckBox *autoUpdateBox;
+  QPushButton *refreshButton;
 };
 
 extern OamViewer *oamViewer;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -55,6 +55,8 @@ private:
   OamCanvas *canvas;
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
+
+  bool inRefreshCall;
 };
 
 extern OamViewer *oamViewer;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -30,9 +30,12 @@ private:
   void refresh4bpp(const uint8_t*);
   void refresh8bpp(const uint8_t*);
   void refreshMode7(const uint8_t*);
+  void refreshScaledImage();
 
 private:
-  QImage *image;
+  QImage image;
+  QImage scaledImage;
+
   unsigned bpp;
   unsigned zoom;
   unsigned selectedColor;


### PR DESCRIPTION
More updates to the bsnes-plus debugger.

 * Only scale the Vram canvas once. Dramatically improves CPU usage when scrolling the Vram Viewer.
 * Display selected object in Sprite Viewer. Fixes #77 
 * Allow user to sort Sprite Viewer columns.