### PR TITLE
[BS-X] Satellaview Signal + Memory Pack changes

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -13,8 +13,8 @@ version := v073+2
 # compiler
 c       := $(compiler) -xc -std=gnu99
 cpp     := $(compiler) -std=gnu++0x
-flags   := -I. -I$(snes)
-link    :=
+flags   := -m32 -I. -I$(snes)
+link    := -m32
 objects :=
 
 ifeq ($(DEBUG), 1)

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -13,8 +13,8 @@ version := v073+2
 # compiler
 c       := $(compiler) -xc -std=gnu99
 cpp     := $(compiler) -std=gnu++0x
-flags   := -m32 -I. -I$(snes)
-link    := -m32
+flags   := -I. -I$(snes)
+link    :=
 objects :=
 
 ifeq ($(DEBUG), 1)

--- a/bsnes/snes/chip/bsx/bsx.hpp
+++ b/bsnes/snes/chip/bsx/bsx.hpp
@@ -1,3 +1,5 @@
+#include <nall/file.hpp>
+
 class BSXBase : public MMIO {
 public:
   void init();
@@ -9,6 +11,13 @@ public:
   void mmio_write(unsigned addr, uint8 data);
 
 private:
+  file SAT1;
+  file SAT2;
+
+  void stream1_fileload(uint8 count);
+  void stream2_fileload(uint8 count);
+  uint8 get_time(bool reset);
+
   struct {
     uint8 r2188, r2189, r218a, r218b;
     uint8 r218c, r218d, r218e, r218f;
@@ -17,8 +26,17 @@ private:
     uint8 r2198, r2199, r219a, r219b;
     uint8 r219c, r219d, r219e, r219f;
 
-    uint8 r2192_counter;
-    uint8 r2192_hour, r2192_minute, r2192_second;
+    uint8 time_counter;
+    uint8 time_hour, time_minute, time_second;
+    uint8 time_weekday, time_day, time_month;
+    uint8 time_yearL, time_yearH;
+
+    bool pf_latch1_enable, dt_latch1_enable;
+    bool pf_latch2_enable, dt_latch2_enable;
+
+    bool stream1_loaded, stream2_loaded;
+    uint8 stream1_count, stream2_count;
+    bool stream1_first, stream2_first;
   } regs;
 };
 

--- a/bsnes/snes/chip/bsx/bsx_base.cpp
+++ b/bsnes/snes/chip/bsx/bsx_base.cpp
@@ -17,61 +17,345 @@ void BSXBase::reset() {
   memset(&regs, 0x00, sizeof regs);
 }
 
+void BSXBase::stream1_fileload(uint8 count)
+{
+  //Make sure to close the file first
+  SAT1.close();
+  char filename[256];
+  sprintf(filename, "./bsxdat/BSX%04X-%d.bin", (regs.r2188 | (regs.r2189 * 256)), count);
+  
+  //Open Satellaview file
+  //if (SAT1.open(filepath(filename, config().path.satdata), file::mode::read))
+  if (SAT1.open(filename, file::mode::read))
+  {
+    regs.stream1_loaded = true;
+    regs.stream1_first = true;
+    float QueueSize = SAT1.size() / 22.;
+    regs.r218a = (uint8)(ceil(QueueSize));
+    regs.stream1_first = true;
+  }
+  else
+  {
+    regs.stream1_loaded = false;
+  }
+}
+
+void BSXBase::stream2_fileload(uint8 count)
+{
+  //Make sure to close the file first
+  SAT2.close();
+  char filename[256];
+  sprintf(filename, "./bsxdat/BSX%04X-%d.bin", (regs.r2188 | (regs.r2189*256)), count);
+
+  //Open Satellaview file
+  //if (SAT2.open(filepath(filename, config().path.satdata), file::mode::read))
+  if (SAT2.open(filename, file::mode::read))
+  {
+    regs.stream2_loaded = true;
+    regs.stream2_first = true;
+    float QueueSize = SAT1.size() / 22.;
+    regs.r2190 = (uint8)(ceil(QueueSize));
+    regs.stream2_first = true;
+  }
+  else
+  {
+    regs.stream2_loaded = false;
+  }
+}
+
+uint8 BSXBase::get_time(bool reset)
+{
+  if(reset == true) {
+    regs.time_counter = 0;
+    return 0xff;
+  }
+  
+  unsigned counter = regs.time_counter;
+  regs.time_counter++;
+  if (regs.time_counter >= 22)
+    regs.time_counter = 0;
+
+  if (counter == 0) {
+    time_t rawtime;
+    time(&rawtime);
+    tm *t = localtime(&rawtime);
+
+    regs.time_hour   = t->tm_hour;
+    regs.time_minute = t->tm_min;
+    regs.time_second = t->tm_sec;
+    regs.time_weekday = (t->tm_wday)++;
+    regs.time_day = (t->tm_mday)++;
+    regs.time_month = t->tm_mon;
+    uint16 time_year = (t->tm_year) + 1900;
+    regs.time_yearL = time_year & 0xFF;
+    regs.time_yearH = time_year >> 8;
+  }
+
+  switch(counter) {
+    case  0: return 0x00;  //Data Group ID / Repetition
+    case  1: return 0x00;  //Data Group Link / Continuity
+    case  2: return 0x00;  //Data Group Size (24-bit)
+    case  3: return 0x00;
+    case  4: return 0x11;
+    case  5: return 0x01;  //Must be 0x01
+    case  6: return 0x01;  //Amount of packets (1)
+    case  7: return 0x00;  //Offset (24-bit)
+    case  8: return 0x00;
+    case  9: return 0x00;
+    case 10: return regs.time_second;
+    case 11: return regs.time_minute;
+    case 12: return regs.time_hour;
+    case 13: return regs.time_weekday;
+    case 14: return regs.time_day;
+    case 15: return regs.time_month;
+    case 16: return regs.time_yearL;
+    case 17: return regs.time_yearH;
+    default: return 0x00;
+  }
+}
+
 uint8 BSXBase::mmio_read(unsigned addr) {
   switch(addr) {
-    case 0x2188: return regs.r2188;
-    case 0x2189: return regs.r2189;
-    case 0x218a: return regs.r218a;
-    case 0x218c: return regs.r218c;
-    case 0x218e: return regs.r218e;
-    case 0x218f: return regs.r218f;
-    case 0x2190: return regs.r2190;
+    //Stream 1
+    case 0x2188: return regs.r2188; //Logical Channel 1 + Data Structure
+    case 0x2189: return regs.r2189; //Logical Channel 2
 
-    case 0x2192: {
-      unsigned counter = regs.r2192_counter;
+    case 0x218a: {
+      //Prefix Data Count
+      if (regs.r2188 == 0 && regs.r2189 == 0)
+      {
+        //Time Channel, one packet
+        return 0x01;
+      }
       
-      if(!Memory::debugger_access()) {
-        regs.r2192_counter++;
-        if(regs.r2192_counter >= 18) regs.r2192_counter = 0;
-
-        if(counter == 0) {
-          time_t rawtime;
-          time(&rawtime);
-          tm *t = localtime(&rawtime);
-
-          regs.r2192_hour   = t->tm_hour;
-          regs.r2192_minute = t->tm_min;
-          regs.r2192_second = t->tm_sec;
+      if(!Memory::debugger_access())
+      {
+        if (regs.r218a <= 0)
+        {
+          //Queue is empty
+          regs.stream1_count++;
+          stream1_fileload(regs.stream1_count - 1);
+        }
+      
+        if (!regs.stream1_loaded && (regs.stream1_count - 1) > 0)
+        {
+          //Not loaded
+          regs.stream1_count = 1;
+          stream1_fileload(regs.stream1_count - 1);
         }
       }
-
-      switch(counter) {
-        case  0: return 0x00;  //???
-        case  1: return 0x00;  //???
-        case  2: return 0x00;  //???
-        case  3: return 0x00;  //???
-        case  4: return 0x00;  //???
-        case  5: return 0x01;
-        case  6: return 0x01;
-        case  7: return 0x00;
-        case  8: return 0x00;
-        case  9: return 0x00;
-        case 10: return regs.r2192_second;
-        case 11: return regs.r2192_minute;
-        case 12: return regs.r2192_hour;
-        case 13: return 0x00;  //???
-        case 14: return 0x00;  //???
-        case 15: return 0x00;  //???
-        case 16: return 0x00;  //???
-        case 17: return 0x00;  //???
+      
+      if (regs.stream1_loaded)
+      {
+        return regs.r218a;
       }
-    } break;
+      else
+      {
+        return 0;
+      }
+    }
+    case 0x218b: {
+      //Prefix Data Latch
+      if (regs.pf_latch1_enable)
+      {
+        //Latch enabled
+        if (regs.r2188 == 0 && regs.r2189 == 0)
+        {
+          //Time Channel, only one packet, both start and end
+          regs.r218b = 0x90;
+        }
 
-    case 0x2193: return regs.r2193 & ~0x0c;
-    case 0x2194: return regs.r2194;
-    case 0x2196: return regs.r2196;
-    case 0x2197: return regs.r2197;
-    case 0x2199: return regs.r2199;
+        if(!Memory::debugger_access())
+        {
+          if (regs.stream1_loaded)
+          {
+            uint8 temp = 0;
+            if (regs.stream1_first)
+            {
+              //First packet
+              temp |= 0x10;
+              regs.stream1_first = false;
+            }
+
+            regs.r218a--;
+            if (regs.r218a == 0)
+            {
+              //Last packet
+              temp |= 0x80;
+            }
+            regs.r218b = temp;
+          }
+        }
+
+        regs.r218d |= regs.r218b;
+        return regs.r218b;
+      }
+      else
+      {
+        //Latch not enabled
+        return 0;
+      }
+    }
+    case 0x218c: {
+      //Data Latch
+      if (regs.dt_latch1_enable)
+      {
+        if(!Memory::debugger_access())
+        {
+          if (regs.r2188 == 0 && regs.r2189 == 0)
+          {
+            //Return Time
+            regs.r218c = get_time(false);
+          }
+        
+          if (regs.stream1_loaded)
+          {
+            //Get packet data
+            regs.r218c = SAT1.read();
+          }
+        }
+        return regs.r218c;
+      }
+      else
+      {
+        return 0;
+      }
+    }
+    case 0x218d: {
+      //Prefix Data OR
+      uint8 temp = regs.r218d;
+      if(!Memory::debugger_access())
+      {
+        regs.r218d = 0;
+      }
+      return temp; 
+    }
+
+    //Stream 2
+    case 0x218e: return regs.r218e; //Logical Channel 1 + Data Structure
+    case 0x218f: return regs.r218f; //Logical Channel 2
+
+    case 0x2190: {
+      //Prefix Data Count
+      if (regs.r218e == 0 && regs.r218f == 0)
+      {
+        //Time Channel, one packet
+        return 0x01;
+      }
+      
+      if(!Memory::debugger_access())
+      {
+        if (regs.r2190 <= 0)
+        {
+          //Queue is empty
+          regs.stream2_count++;
+          stream2_fileload(regs.stream2_count - 1);
+        }
+      
+        if (!regs.stream2_loaded && (regs.stream2_count - 1) > 0)
+        {
+          //Not loaded
+          regs.stream2_count = 1;
+          stream2_fileload(regs.stream2_count - 1);
+        }
+      }
+      
+      if (regs.stream2_loaded)
+      {
+        return regs.r2190;
+      }
+      else
+      {
+        return 0;
+      }
+    }
+    case 0x2191: {
+      //Prefix Data Latch
+      if (regs.pf_latch2_enable)
+      {
+        //Latch enabled
+        if (regs.r218e == 0 && regs.r218f == 0)
+        {
+          //Time Channel, only one packet, both start and end
+          regs.r2191 = 0x90;
+        }
+
+        if(!Memory::debugger_access())
+        {
+          if (regs.stream2_loaded)
+          {
+            uint8 temp = 0;
+            if (regs.stream2_first)
+            {
+              //First packet
+              temp |= 0x10;
+              regs.stream2_first = false;
+            }
+
+            regs.r2190--;
+            if (regs.r2190 == 0)
+            {
+              //Last packet
+              temp |= 0x80;
+            }
+            regs.r2191 = temp;
+          }
+        }
+
+        regs.r2193 |= regs.r2191;
+        return regs.r2191;
+      }
+      else
+      {
+        //Latch not enabled
+        return 0;
+      }
+    }
+
+    case 0x2192: {
+      //Data Latch
+      if (regs.dt_latch2_enable)
+      {
+        if(!Memory::debugger_access())
+        {
+          if (regs.r218e == 0 && regs.r218f == 0)
+          {
+            //Return Time
+            regs.r2192 = get_time(false);
+          }
+        
+          if (regs.stream1_loaded)
+          {
+            //Get packet data
+            regs.r2192 = SAT1.read();
+          }
+        }
+
+        return regs.r2192;
+      }
+      else
+      {
+        return 0;
+      }
+    }
+
+    case 0x2193: {
+      //Prefix Data OR
+      uint8 temp = regs.r2193;
+      if(!Memory::debugger_access())
+      {
+        regs.r2193 = 0;
+      }
+      return temp;
+    }
+
+    //Other
+    case 0x2194: return regs.r2194; //Satellaview LED and Stream register
+    case 0x2195: return regs.r2195; //Unknown
+    case 0x2196: return regs.r2196; //Satellaview Status
+    case 0x2197: return regs.r2197; //Soundlink
+    case 0x2198: return regs.r2198; //Serial I/O - Serial Number
+    case 0x2199: return regs.r2199; //Serial I/O - ???
   }
 
   return cpu.regs.mdr;
@@ -79,59 +363,77 @@ uint8 BSXBase::mmio_read(unsigned addr) {
 
 void BSXBase::mmio_write(unsigned addr, uint8 data) {
   switch(addr) {
+    //Stream 1
     case 0x2188: {
+      //Logical Channel 1 + Data Structure
+      if (regs.r2188 != data)
+        regs.stream1_count = 0;
       regs.r2188 = data;
     } break;
 
     case 0x2189: {
-      regs.r2189 = data;
-    } break;
-
-    case 0x218a: {
-      regs.r218a = data;
+      //Logical Channel 2 (6bit)
+      if (regs.r2189 != (data & 0x3F))
+        regs.stream1_count = 0;
+      regs.r2189 = data & 0x3F;
     } break;
 
     case 0x218b: {
-      regs.r218b = data;
+      //Prefix Data Latch
+      regs.pf_latch1_enable = (data & 1 == 1);
     } break;
 
     case 0x218c: {
-      regs.r218c = data;
+      //Data Latch
+      if (regs.r2188 == 0 && regs.r2189 == 0 && !Memory::debugger_access())
+      {
+        //Hardcoded Time Channel
+        get_time(true);
+      }
+      regs.dt_latch1_enable = (data & 1 == 1);
     } break;
 
+
+    //Stream 2
     case 0x218e: {
+      //Logical Channel 1 + Data Structure
+      if (regs.r218e != data)
+        regs.stream2_count = 0;
       regs.r218e = data;
     } break;
 
     case 0x218f: {
-      regs.r218e >>= 1;
-      regs.r218e = regs.r218f - regs.r218e;
-      regs.r218f >>= 1;
+      //Logical Channel 2 (6bit)
+      if (regs.r218f != (data & 0x3F))
+        regs.stream2_count = 0;
+      regs.r218f = data & 0x3F;
     } break;
 
     case 0x2191: {
-      regs.r2191 = data;
-      regs.r2192_counter = 0;
+      //Prefix Data Latch
+      regs.pf_latch2_enable = (data & 1 == 1);
     } break;
 
     case 0x2192: {
-      regs.r2190 = 0x80;
+      //Data Latch
+      if (regs.r218e == 0 && regs.r218f == 0 && !Memory::debugger_access())
+      {
+        //Hardcoded Time Channel
+        get_time(true);
+      }
+      regs.dt_latch2_enable = (data & 1 == 1);
     } break;
 
-    case 0x2193: {
-      regs.r2193 = data;
-    } break;
 
+    //Other
     case 0x2194: {
-      regs.r2194 = data;
+      //Satellaview LED and Stream enable (4bit)
+      regs.r2194 = data & 0x0F;
     } break;
 
     case 0x2197: {
+      //Soundlink
       regs.r2197 = data;
-    } break;
-
-    case 0x2199: {
-      regs.r2199 = data;
     } break;
   }
 }

--- a/bsnes/snes/chip/bsx/bsx_base.cpp
+++ b/bsnes/snes/chip/bsx/bsx_base.cpp
@@ -322,7 +322,7 @@ uint8 BSXBase::mmio_read(unsigned addr) {
             //Return Time
             regs.r2192 = get_time(false);
           }
-          else if (regs.stream1_loaded)
+          else if (regs.stream2_loaded)
           {
             //Get packet data
             regs.r2192 = SAT1.read();

--- a/bsnes/snes/chip/bsx/bsx_base.cpp
+++ b/bsnes/snes/chip/bsx/bsx_base.cpp
@@ -96,7 +96,7 @@ uint8 BSXBase::get_time(bool reset)
     case  1: return 0x00;  //Data Group Link / Continuity
     case  2: return 0x00;  //Data Group Size (24-bit)
     case  3: return 0x00;
-    case  4: return 0x11;
+    case  4: return 0x10;
     case  5: return 0x01;  //Must be 0x01
     case  6: return 0x01;  //Amount of packets (1)
     case  7: return 0x00;  //Offset (24-bit)
@@ -207,8 +207,7 @@ uint8 BSXBase::mmio_read(unsigned addr) {
             //Return Time
             regs.r218c = get_time(false);
           }
-        
-          if (regs.stream1_loaded)
+          else if (regs.stream1_loaded)
           {
             //Get packet data
             regs.r218c = SAT1.read();
@@ -323,8 +322,7 @@ uint8 BSXBase::mmio_read(unsigned addr) {
             //Return Time
             regs.r2192 = get_time(false);
           }
-        
-          if (regs.stream1_loaded)
+          else if (regs.stream1_loaded)
           {
             //Get packet data
             regs.r2192 = SAT1.read();

--- a/bsnes/snes/chip/bsx/bsx_base.cpp
+++ b/bsnes/snes/chip/bsx/bsx_base.cpp
@@ -22,11 +22,12 @@ void BSXBase::stream1_fileload(uint8 count)
   //Make sure to close the file first
   SAT1.close();
   char filename[256];
-  sprintf(filename, "./bsxdat/BSX%04X-%d.bin", (regs.r2188 | (regs.r2189 * 256)), count);
+  string filepath;
+  sprintf(filename, "BSX%04X-%d.bin", (regs.r2188 | (regs.r2189 * 256)), count);
+  filepath << config.sat.path << filename;
   
   //Open Satellaview file
-  //if (SAT1.open(filepath(filename, config().path.satdata), file::mode::read))
-  if (SAT1.open(filename, file::mode::read))
+  if (SAT1.open(filepath, file::mode::read))
   {
     regs.stream1_loaded = true;
     regs.stream1_first = true;
@@ -45,11 +46,12 @@ void BSXBase::stream2_fileload(uint8 count)
   //Make sure to close the file first
   SAT2.close();
   char filename[256];
-  sprintf(filename, "./bsxdat/BSX%04X-%d.bin", (regs.r2188 | (regs.r2189*256)), count);
+  string filepath;
+  sprintf(filename, "BSX%04X-%d.bin", (regs.r218e | (regs.r218f * 256)), count);
+  filepath << config.sat.path << filename;
 
   //Open Satellaview file
-  //if (SAT2.open(filepath(filename, config().path.satdata), file::mode::read))
-  if (SAT2.open(filename, file::mode::read))
+  if (SAT2.open(filepath, file::mode::read))
   {
     regs.stream2_loaded = true;
     regs.stream2_first = true;

--- a/bsnes/snes/config/config.cpp
+++ b/bsnes/snes/config/config.cpp
@@ -19,6 +19,8 @@ Configuration::Configuration() {
 
   ppu1.version = 1;
   ppu2.version = 3;
+
+  sat.path = "./bsxdat/";
 }
 
 #endif

--- a/bsnes/snes/config/config.hpp
+++ b/bsnes/snes/config/config.hpp
@@ -25,6 +25,10 @@ struct Configuration {
     unsigned version;
   } ppu2;
 
+  struct Satellaview {
+    string path;
+  } sat;
+
   Configuration();
 };
 

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -30,6 +30,7 @@ MainWindow::MainWindow() {
   system_loadSpecial_superGameBoy = system_loadSpecial->addAction("Load Super &Game Boy Cartridge ...");
 
   system_saveMemoryPack = system->addAction("Save Memory Pack");
+  system_saveMemoryPack->setVisible(false);
 
   system_reload = system->addAction("Re&load");
 

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -29,6 +29,8 @@ MainWindow::MainWindow() {
 
   system_loadSpecial_superGameBoy = system_loadSpecial->addAction("Load Super &Game Boy Cartridge ...");
 
+  system_saveMemoryPack = system->addAction("Save Memory Pack");
+
   system_reload = system->addAction("Re&load");
 
   system->addSeparator();
@@ -253,6 +255,7 @@ MainWindow::MainWindow() {
   connect(system_loadSpecial_bsx, SIGNAL(triggered()), this, SLOT(loadBsxCartridge()));
   connect(system_loadSpecial_sufamiTurbo, SIGNAL(triggered()), this, SLOT(loadSufamiTurboCartridge()));
   connect(system_loadSpecial_superGameBoy, SIGNAL(triggered()), this, SLOT(loadSuperGameBoyCartridge()));
+  connect(system_saveMemoryPack, SIGNAL(triggered()), this, SLOT(saveMemoryPack()));
   connect(system_power, SIGNAL(triggered()), this, SLOT(power()));
   connect(system_reset, SIGNAL(triggered()), this, SLOT(reset()));
   connect(system_port1_none, SIGNAL(triggered()), this, SLOT(setPort1None()));
@@ -411,6 +414,10 @@ void MainWindow::loadSufamiTurboCartridge() {
 
 void MainWindow::loadSuperGameBoyCartridge() {
   loaderWindow->loadSuperGameBoyCartridge(config().path.sgb, "");
+}
+
+void MainWindow::saveMemoryPack() {
+  cartridge.saveMemoryPack();
 }
 
 void MainWindow::power() {

--- a/bsnes/ui-qt/base/main.moc.hpp
+++ b/bsnes/ui-qt/base/main.moc.hpp
@@ -28,6 +28,7 @@ public:
       QAction *system_loadSpecial_bsx;
       QAction *system_loadSpecial_sufamiTurbo;
       QAction *system_loadSpecial_superGameBoy;
+    QAction *system_saveMemoryPack;
     CheckAction *system_power;
     QAction *system_reset;
     QMenu *system_port1;
@@ -112,6 +113,7 @@ public slots:
   void loadBsxCartridge();
   void loadSufamiTurboCartridge();
   void loadSuperGameBoyCartridge();
+  void saveMemoryPack();
   void power();
   void reset();
   void reloadCartridge();

--- a/bsnes/ui-qt/cartridge/cartridge.cpp
+++ b/bsnes/ui-qt/cartridge/cartridge.cpp
@@ -123,7 +123,7 @@ bool Cartridge::loadNormal(const char *base) {
 bool Cartridge::loadBsxSlotted(const char *base, const char *slot) {
   unload();
   if(loadCartridge(baseName = base, cartridge.baseXml, SNES::memory::cartrom) == false) return false;
-  loadCartridge(slotAName = slot, cartridge.slotAXml, SNES::memory::bsxpack);
+  if(loadCartridge(slotAName = slot, cartridge.slotAXml, SNES::memory::bsxpack) == false) loadEmptyMemoryPack(SNES::memory::bsxpack);
   SNES::cartridge.basename = nall::basename(baseName);
 
   SNES::cartridge.load(SNES::Cartridge::Mode::BsxSlotted,
@@ -143,7 +143,7 @@ bool Cartridge::loadBsxSlotted(const char *base, const char *slot) {
 bool Cartridge::loadBsx(const char *base, const char *slot) {
   unload();
   if(loadCartridge(baseName = base, cartridge.baseXml, SNES::memory::cartrom) == false) return false;
-  loadCartridge(slotAName = slot, cartridge.slotAXml, SNES::memory::bsxpack);
+  if(loadCartridge(slotAName = slot, cartridge.slotAXml, SNES::memory::bsxpack) == false) loadEmptyMemoryPack(SNES::memory::bsxpack);
   SNES::cartridge.basename = nall::basename(baseName);
 
   SNES::cartridge.load(SNES::Cartridge::Mode::Bsx,
@@ -431,6 +431,13 @@ bool Cartridge::saveMemory(const char *filename, const char *extension, SNES::Ma
 
   fp.write(memory.data(), memory.size());
   fp.close();
+  return true;
+}
+
+bool Cartridge::loadEmptyMemoryPack(SNES::MappedRAM &memory) {
+  uint8_t *emptydata = new uint8_t[0x100000];
+  memset(emptydata, 0xFF, 0x100000);
+  memory.copy(emptydata, 0x100000);
   return true;
 }
 

--- a/bsnes/ui-qt/cartridge/cartridge.cpp
+++ b/bsnes/ui-qt/cartridge/cartridge.cpp
@@ -152,7 +152,11 @@ bool Cartridge::loadBsx(const char *base, const char *slot) {
   loadMemory(baseName, ".srm", SNES::memory::cartram);
   loadMemory(baseName, ".psr", SNES::memory::bsxpram);
 
-  fileName = slotAName;
+  if (slotAName != "")
+    fileName = slotAName;
+  else
+    fileName = baseName;
+  
   name = *slot
   ? notdir(nall::basename(slotAName))
   : notdir(nall::basename(baseName));

--- a/bsnes/ui-qt/cartridge/cartridge.cpp
+++ b/bsnes/ui-qt/cartridge/cartridge.cpp
@@ -438,6 +438,7 @@ bool Cartridge::loadEmptyMemoryPack(SNES::MappedRAM &memory) {
   uint8_t *emptydata = new uint8_t[0x100000];
   memset(emptydata, 0xFF, 0x100000);
   memory.copy(emptydata, 0x100000);
+  delete[] emptydata;
   return true;
 }
 

--- a/bsnes/ui-qt/cartridge/cartridge.cpp
+++ b/bsnes/ui-qt/cartridge/cartridge.cpp
@@ -232,6 +232,35 @@ void Cartridge::saveMemory() {
   }
 }
 
+void Cartridge::saveMemoryPack() {
+  if(SNES::cartridge.loaded() == false) return;
+  if(SNES::cartridge.has_bsx_slot() == false) return;
+
+  string filename = nall::basename(cartridge.fileName);
+  string fullpath = config().path.save;
+  
+  time_t systemTime = time(0);
+  tm *currentTime = localtime(&systemTime);
+  char t[512];
+  sprintf(t, "%.4u%.2u%.2u-%.2u%.2u%.2u",
+    1900 + currentTime->tm_year, 1 + currentTime->tm_mon, currentTime->tm_mday,
+    currentTime->tm_hour, currentTime->tm_min, currentTime->tm_sec
+  );
+  filename << "-" << t << ".bs";
+  fullpath << filename;
+
+  file fp;
+  if(fp.open(fullpath, file::mode::write) == false)
+  {
+    utility.showMessage(string("Memory Pack save failed."));
+    return;
+  }
+
+  fp.write(SNES::memory::bsxpack.data(), SNES::memory::bsxpack.size());
+  fp.close();
+  utility.showMessage(string(filename, " saved."));
+}
+
 void Cartridge::unload() {
   if(SNES::cartridge.loaded() == false) return;
   utility.modifySystemState(Utility::UnloadCartridge);

--- a/bsnes/ui-qt/cartridge/cartridge.hpp
+++ b/bsnes/ui-qt/cartridge/cartridge.hpp
@@ -27,6 +27,7 @@ public:
   bool loadSufamiTurbo(const char*, const char *, const char*);
   bool loadSuperGameBoy(const char*, const char*);
   void saveMemory();
+  void saveMemoryPack();
   void unload();
 
   void loadCheats();

--- a/bsnes/ui-qt/cartridge/cartridge.hpp
+++ b/bsnes/ui-qt/cartridge/cartridge.hpp
@@ -36,6 +36,7 @@ private:
   bool loadCartridge(string&, string&, SNES::MappedRAM&);
   bool loadMemory(const char*, const char*, SNES::MappedRAM&);
   bool saveMemory(const char*, const char*, SNES::MappedRAM&);
+  bool loadEmptyMemoryPack(SNES::MappedRAM&);
   bool applyBPS(string&, uint8_t *&data, unsigned &size);
   bool applyUPS(string&, uint8_t *&data, unsigned &size);
   bool applyIPS(string&, uint8_t *&data, unsigned &size);

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -29,6 +29,8 @@ Configuration::Configuration() {
   attach(SNES::config.ppu1.version = 1, "ppu1.version", "Valid version(s) are: 1");
   attach(SNES::config.ppu2.version = 3, "ppu2.version", "Valid version(s) are: 1, 2, 3");
 
+  attach(SNES::config.sat.path = "./bsxdat/", "path.satdata");
+
   //TODO: add superfx frequency
 
   //internal

--- a/bsnes/ui-qt/settings/paths.cpp
+++ b/bsnes/ui-qt/settings/paths.cpp
@@ -1,9 +1,10 @@
 #include "paths.moc"
 PathSettingsWindow *pathSettingsWindow;
 
-PathSettingWidget::PathSettingWidget(string &pathValue_, const char *labelText, const char *pathDefaultLabel_, const char *pathBrowseLabel_) : pathValue(pathValue_) {
+PathSettingWidget::PathSettingWidget(string &pathValue_, const char *labelText, const char *pathDefaultLabel_, const char *pathBrowseLabel_, const char *pathDefaultValue_) : pathValue(pathValue_) {
   pathDefaultLabel = pathDefaultLabel_;
   pathBrowseLabel = pathBrowseLabel_;
+  pathDefaultValue = pathDefaultValue_;
 
   layout = new QVBoxLayout;
   layout->setMargin(0);
@@ -40,7 +41,7 @@ void PathSettingWidget::acceptPath(const string &newPath) {
 }
 
 void PathSettingWidget::updatePath() {
-  if(pathValue == "") {
+  if(pathValue == pathDefaultValue) {
     path->setStyleSheet("color: #808080");
     path->setText(pathDefaultLabel);
   } else {
@@ -59,7 +60,7 @@ void PathSettingWidget::selectPath() {
 }
 
 void PathSettingWidget::defaultPath() {
-  pathValue = "";
+  pathValue = pathDefaultValue;
   updatePath();
 }
 
@@ -70,12 +71,13 @@ PathSettingsWindow::PathSettingsWindow() {
   layout->setAlignment(Qt::AlignTop);
   setLayout(layout);
 
-  gamePath  = new PathSettingWidget(config().path.rom,   "Games:",         "Remember last path",  "Default Game Path");
-  savePath  = new PathSettingWidget(config().path.save,  "Save RAM:",      "Same as loaded game", "Default Save RAM Path");
-  statePath = new PathSettingWidget(config().path.state, "Save states:",   "Same as loaded game", "Default Save State Path");
-  patchPath = new PathSettingWidget(config().path.patch, "BPS/UPS/IPS patches:",   "Same as loaded game", "Default BPS/UPS/IPS Patch Path");
-  cheatPath = new PathSettingWidget(config().path.cheat, "Cheat codes:",   "Same as loaded game", "Default Cheat Code Path");
-  dataPath  = new PathSettingWidget(config().path.data,  "Exported data:", "Same as loaded game", "Default Exported Data Path");
+  gamePath  = new PathSettingWidget(config().path.rom,   "Games:",         "Remember last path",  "Default Game Path", "");
+  savePath  = new PathSettingWidget(config().path.save,  "Save RAM:",      "Same as loaded game", "Default Save RAM Path", "");
+  statePath = new PathSettingWidget(config().path.state, "Save states:",   "Same as loaded game", "Default Save State Path", "");
+  patchPath = new PathSettingWidget(config().path.patch, "BPS/UPS/IPS patches:",   "Same as loaded game", "Default BPS/UPS/IPS Patch Path", "");
+  cheatPath = new PathSettingWidget(config().path.cheat, "Cheat codes:",   "Same as loaded game", "Default Cheat Code Path", "");
+  dataPath  = new PathSettingWidget(config().path.data,  "Exported data:", "Same as loaded game", "Default Exported Data Path", "");
+  satdataPath  = new PathSettingWidget(SNES::config.sat.path,  "Satellaview signal data:", "./bsxdat/", "Default Satellaview Signal Data Path", "./bsxdat/");
 
   layout->addWidget(gamePath);
   layout->addWidget(savePath);
@@ -83,4 +85,5 @@ PathSettingsWindow::PathSettingsWindow() {
   layout->addWidget(patchPath);
   layout->addWidget(cheatPath);
   layout->addWidget(dataPath);
+  layout->addWidget(satdataPath);
 }

--- a/bsnes/ui-qt/settings/paths.moc.hpp
+++ b/bsnes/ui-qt/settings/paths.moc.hpp
@@ -12,10 +12,11 @@ public:
   string &pathValue;
   string pathDefaultLabel;
   string pathBrowseLabel;
+  string pathDefaultValue;
   void acceptPath(const string&);
   void updatePath();
 
-  PathSettingWidget(string&, const char*, const char*, const char*);
+  PathSettingWidget(string&, const char*, const char*, const char*, const char*);
 
 public slots:
   void selectPath();
@@ -33,6 +34,7 @@ public:
   PathSettingWidget *patchPath;
   PathSettingWidget *cheatPath;
   PathSettingWidget *dataPath;
+  PathSettingWidget *satdataPath;
 
   PathSettingsWindow();
 };

--- a/bsnes/ui-qt/utility/system-state.cpp
+++ b/bsnes/ui-qt/utility/system-state.cpp
@@ -100,6 +100,7 @@ void Utility::modifySystemState(system_state_t systemState) {
     } break;
   }
 
+  mainWindow->system_saveMemoryPack->setVisible(SNES::cartridge.loaded() && SNES::cartridge.has_bsx_slot() && (SNES::memory::bsxpack.size() > 0));
   mainWindow->syncUi();
   #if defined(DEBUGGER)
   debugger->modifySystemState(systemState);


### PR DESCRIPTION
**It's merged.**

Done:
- Satellaview Signal Support
- 1MB Empty Memory Pack loaded by default
- Memory Pack Saving option
- Allow custom path for Satellaview data files (could probably be done better, such as the default folder name)

Todo:
- Allow custom time & date (that's actually a feature people would want)