### PR TITLE
Minor tweaks for OSX build

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -22,7 +22,7 @@ ifeq ($(DEBUG), 1)
 else
   flags += -O3 -fomit-frame-pointer
   ifeq ($(platform),osx)
-    # -s is deprecated as of clang 7.0, and using it breaks linking for some reason
+    # -s is deprecated as of Apple LLVM 7.0, and using it breaks linking with some versions
   else
     link += -s
   endif
@@ -81,7 +81,7 @@ ifeq ($(platform),osx)
 	$(strip $(cpp) -o $(osxbundle)/Contents/MacOS/bsnes $(objects) $(link))
 	mkdir -p $(osxbundle)/Contents/Resources
 	cp -f data/bsnes.icns $(osxbundle)/Contents/Resources/AppIcon.icns
-	cp -f data/Info.plist $(osxbundle)/Contents/Info.plist
+	sed 's/@VERSION/$(version)/g' data/Info.plist > $(osxbundle)/Contents/Info.plist
 else
 	$(strip $(cpp) -o out/bsnes $(objects) $(link))
 endif
@@ -112,14 +112,12 @@ endif
 
 plugins: build
 	@$(MAKE) -C ../snesreader
-ifneq ($(platform), osx)
 	@$(MAKE) -C ../snesfilter
-endif
 	@$(MAKE) -C ../supergameboy
 ifeq ($(platform),osx)
 	mkdir -p $(osxbundle)/Contents/Frameworks
 	cp -f ../snesreader/libsnesreader.dylib $(osxbundle)/Contents/Frameworks/libsnesreader.dylib
-#	cp -f ../snesfilter/libsnesfilter.dylib $(osxbundle)/Contents/Frameworks/libsnesfilter.dylib
+	cp -f ../snesfilter/libsnesfilter.dylib $(osxbundle)/Contents/Frameworks/libsnesfilter.dylib
 	cp -f ../supergameboy/libsupergameboy.dylib $(osxbundle)/Contents/Frameworks/libsupergameboy.dylib
 endif
 
@@ -129,10 +127,10 @@ ifeq ($(platform),osx)
 	@zip -9 -r ../bsnes_$(version)_osx.zip $(osxbundle)
 	@rm -rf $(osxbundle)
 else
-	@echo Distribution building not available for current platform
+	@echo Distribution target not available for current platform
 endif
 
-clean: ui_clean
+clean: ui_clean plugins_clean
 	-@$(call delete,obj/*.o)
 	-@$(call delete,obj/*.a)
 	-@$(call delete,obj/*.so)
@@ -147,6 +145,11 @@ clean: ui_clean
 ifeq ($(platform),osx)
 	@rm -rf $(osxbundle)
 endif
+
+plugins_clean:
+	@$(MAKE) clean -C ../snesreader
+	@$(MAKE) clean -C ../snesfilter
+	@$(MAKE) clean -C ../supergameboy
 
 archive-all:
 	tar -cjf bsnes.tar.bz2 data launcher libco nall obj out phoenix ruby snes ui-phoenix ui-qt Makefile cc.bat clean.bat sync.sh

--- a/bsnes/data/Info.plist
+++ b/bsnes/data/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>v073+3</string>
+	<string>@VERSION</string>
 	<key>CFBundleVersion</key>
-	<string>v073+3</string>
+	<string>@VERSION</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.6</string>
 	<key>NSPrincipalClass</key>

--- a/snesfilter/snesfilter.cpp
+++ b/snesfilter/snesfilter.cpp
@@ -14,6 +14,7 @@
 #include <QtGui>
 
 #include <nall/config.hpp>
+#include <nall/detect.hpp>
 #include <nall/platform.hpp>
 #include <nall/string.hpp>
 using namespace nall;
@@ -22,15 +23,21 @@ const uint32_t *colortable;
 configuration *config;
 
 #include "direct/direct.cpp"
-#include "pixellate2x/pixellate2x.cpp"
-#include "scale2x/scale2x.cpp"
-#include "2xsai/2xsai.cpp"
-#include "lq2x/lq2x.cpp"
-#include "hq2x/hq2x.cpp"
 #include "ntsc/ntsc.cpp"
+#if !defined(PLATFORM_OSX)
+  #include "pixellate2x/pixellate2x.cpp"
+  #include "scale2x/scale2x.cpp"
+  #include "2xsai/2xsai.cpp"
+  #include "lq2x/lq2x.cpp"
+  #include "hq2x/hq2x.cpp"
+#endif
 
 bsnesexport const char* snesfilter_supported() {
-  return "Pixellate2x;Scale2x;2xSaI;Super 2xSaI;Super Eagle;LQ2x;HQ2x;NTSC";
+  #if defined(PLATFORM_OSX)
+    return "NTSC";
+  #else
+    return "Pixellate2x;Scale2x;2xSaI;Super 2xSaI;Super Eagle;LQ2x;HQ2x;NTSC";
+  #endif
 }
 
 bsnesexport void snesfilter_configuration(configuration &config_) {
@@ -47,14 +54,18 @@ bsnesexport void snesfilter_colortable(const uint32_t *colortable_) {
 bsnesexport void snesfilter_size(unsigned filter, unsigned &outwidth, unsigned &outheight, unsigned width, unsigned height) {
   switch(filter) {
     default: return filter_direct.size(outwidth, outheight, width, height);
-    case 1:  return filter_pixellate2x.size(outwidth, outheight, width, height);
-    case 2:  return filter_scale2x.size(outwidth, outheight, width, height);
-    case 3:  return filter_2xsai.size(outwidth, outheight, width, height);
-    case 4:  return filter_super2xsai.size(outwidth, outheight, width, height);
-    case 5:  return filter_supereagle.size(outwidth, outheight, width, height);
-    case 6:  return filter_lq2x.size(outwidth, outheight, width, height);
-    case 7:  return filter_hq2x.size(outwidth, outheight, width, height);
-    case 8:  return filter_ntsc.size(outwidth, outheight, width, height);
+    #if defined(PLATFORM_OSX)
+      case 1:  return filter_ntsc.size(outwidth, outheight, width, height);
+    #else
+      case 1:  return filter_pixellate2x.size(outwidth, outheight, width, height);
+      case 2:  return filter_scale2x.size(outwidth, outheight, width, height);
+      case 3:  return filter_2xsai.size(outwidth, outheight, width, height);
+      case 4:  return filter_super2xsai.size(outwidth, outheight, width, height);
+      case 5:  return filter_supereagle.size(outwidth, outheight, width, height);
+      case 6:  return filter_lq2x.size(outwidth, outheight, width, height);
+      case 7:  return filter_hq2x.size(outwidth, outheight, width, height);
+      case 8:  return filter_ntsc.size(outwidth, outheight, width, height);
+    #endif
   }
 }
 
@@ -64,20 +75,29 @@ bsnesexport void snesfilter_render(
 ) {
   switch(filter) {
     default: return filter_direct.render(output, outpitch, input, pitch, width, height);
-    case 1:  return filter_pixellate2x.render(output, outpitch, input, pitch, width, height);
-    case 2:  return filter_scale2x.render(output, outpitch, input, pitch, width, height);
-    case 3:  return filter_2xsai.render(output, outpitch, input, pitch, width, height);
-    case 4:  return filter_super2xsai.render(output, outpitch, input, pitch, width, height);
-    case 5:  return filter_supereagle.render(output, outpitch, input, pitch, width, height);
-    case 6:  return filter_lq2x.render(output, outpitch, input, pitch, width, height);
-    case 7:  return filter_hq2x.render(output, outpitch, input, pitch, width, height);
-    case 8:  return filter_ntsc.render(output, outpitch, input, pitch, width, height);
+    #if defined(PLATFORM_OSX)
+      case 1:  return filter_ntsc.render(output, outpitch, input, pitch, width, height);
+    #else
+      case 1:  return filter_pixellate2x.render(output, outpitch, input, pitch, width, height);
+      case 2:  return filter_scale2x.render(output, outpitch, input, pitch, width, height);
+      case 3:  return filter_2xsai.render(output, outpitch, input, pitch, width, height);
+      case 4:  return filter_super2xsai.render(output, outpitch, input, pitch, width, height);
+      case 5:  return filter_supereagle.render(output, outpitch, input, pitch, width, height);
+      case 6:  return filter_lq2x.render(output, outpitch, input, pitch, width, height);
+      case 7:  return filter_hq2x.render(output, outpitch, input, pitch, width, height);
+      case 8:  return filter_ntsc.render(output, outpitch, input, pitch, width, height);
+    #endif
   }
 }
 
 bsnesexport QWidget* snesfilter_settings(unsigned filter) {
   switch(filter) {
     default: return 0;
-    case 8:  return filter_ntsc.settings();
+    #if defined(PLATFORM_OSX)
+      case 1:
+    #else
+      case 8:
+    #endif
+      return filter_ntsc.settings();
   }
 }


### PR DESCRIPTION
Simplified building by automatically adding version string to Info.plist while building.

I also re-enabled snesfilter on the OSX build. NTSC filter works (and it's the best one!), but the other filters seems to just pass through the original image regardless of scale.
