### PR TITLE
macOS distribution buildscript and "bsxdat" searchpath

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -72,6 +72,10 @@ all: build plugins;
 include $(snes)/Makefile
 include $(ui)/Makefile
 
+# including CoreFoundation in nall/string/platform.hpp polluted the global namespace
+objects += nall-string-platform
+obj/nall-string-platform.o: nall/string/platform.cpp
+
 objects := $(patsubst %,obj/%.o,$(objects))
 
 # targets

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -123,9 +123,7 @@ endif
 
 distribution: clean build plugins
 ifeq ($(platform),osx)
-	@rm -f ../bsnes_$(version)_osx.zip
-	@zip -9 -r ../bsnes_$(version)_osx.zip $(osxbundle)
-	@rm -rf $(osxbundle)
+	@macdeployqt $(osxbundle) -executable=$(osxbundle)/Contents/MacOS/bsnes
 else
 	@echo Distribution target not available for current platform
 endif

--- a/bsnes/data/Info.plist
+++ b/bsnes/data/Info.plist
@@ -22,7 +22,7 @@
 	<string>10.6</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-  <key>NSHighResolutionCapable</key>
-  <true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/bsnes/nall/string/platform.cpp
+++ b/bsnes/nall/string/platform.cpp
@@ -1,0 +1,22 @@
+#include <nall/detect.hpp>
+#include <nall/string.hpp>
+
+#if defined(PLATFORM_OSX)
+#include "CoreFoundation/CoreFoundation.h"
+#endif
+
+nall::string nall::launchpath() {
+#if defined(PLATFORM_OSX)
+  CFBundleRef mainBundle = CFBundleGetMainBundle();
+  CFURLRef bundleURL = CFBundleCopyBundleURL(mainBundle);
+  char path[PATH_MAX];
+  if (!CFURLGetFileSystemRepresentation(bundleURL, TRUE, (UInt8 *)path, PATH_MAX))
+  {
+    return "";
+  }
+  CFRelease(bundleURL);
+  return nall::dir(nall::string() << path);
+#else
+  return nall::currentpath();
+#endif
+}

--- a/bsnes/nall/string/platform.hpp
+++ b/bsnes/nall/string/platform.hpp
@@ -36,6 +36,8 @@ string currentpath() {
   return "";
 }
 
+string launchpath();
+
 }
 
 #endif

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -29,7 +29,12 @@ Configuration::Configuration() {
   attach(SNES::config.ppu1.version = 1, "ppu1.version", "Valid version(s) are: 1");
   attach(SNES::config.ppu2.version = 3, "ppu2.version", "Valid version(s) are: 1, 2, 3");
 
+#if defined(PLATFORM_OSX)
+  attach(SNES::config.sat.path = nall::launchpath() << "bsxdat/", "bsx.satdata");
+#else
   attach(SNES::config.sat.path = "./bsxdat/", "bsx.satdata");
+#endif
+
   attach(SNES::config.sat.local_time = true, "bsx.localTime");
   attach((signed&)(SNES::config.sat.custom_time = 798653040) /* 1995-04-23 16:04 */, "bsx.customTime");
 

--- a/bsnes/ui-qt/settings/paths.cpp
+++ b/bsnes/ui-qt/settings/paths.cpp
@@ -77,7 +77,11 @@ PathSettingsWindow::PathSettingsWindow() {
   patchPath = new PathSettingWidget(config().path.patch, "BPS/UPS/IPS patches:",   "Same as loaded game", "Default BPS/UPS/IPS Patch Path", "");
   cheatPath = new PathSettingWidget(config().path.cheat, "Cheat codes:",   "Same as loaded game", "Default Cheat Code Path", "");
   dataPath  = new PathSettingWidget(config().path.data,  "Exported data:", "Same as loaded game", "Default Exported Data Path", "");
+#if defined(PLATFORM_OSX)
+  satdataPath  = new PathSettingWidget(SNES::config.sat.path,  "Satellaview signal data:", nall::launchpath() << "bsxdat/", "Default Satellaview Signal Data Path", nall::launchpath() << "bsxdat/");
+#else
   satdataPath  = new PathSettingWidget(SNES::config.sat.path,  "Satellaview signal data:", "./bsxdat/", "Default Satellaview Signal Data Path", "./bsxdat/");
+#endif
 
   layout->addWidget(gamePath);
   layout->addWidget(savePath);

--- a/build_distribution_osx
+++ b/build_distribution_osx
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+version=`grep -m 1 'version := ' bsnes/Makefile | awk '{ print $3 }'`;
+dist_dir=./bsnes_${version}
+dist_zip=${dist_dir}.zip
+
+#clean & set up distribution directory
+rm -frd ${dist_dir}
+rm -f ${dist_zip}
+mkdir -pv ${dist_dir}
+cp -a bsnes/data/bsxdat ${dist_dir}/bsxdat
+
+#build compatibility app bundle
+cd bsnes
+make distribution profile=compatibility
+cd ..
+mv ./bsnes+.app ${dist_dir}/bsnes+.app
+
+#build accuracy app bundle
+cd bsnes
+make distribution profile=accuracy
+cd ..
+mv ./bsnes+.app ${dist_dir}/bsnes+\ \(accuracy\).app
+
+#zip distribution directory
+zip -9 -r ${dist_dir}.zip ${dist_dir}


### PR DESCRIPTION
I did feel a bit bad about including a cpp file in the previously header-only "nall" namespace, but it seemed like the lesser evil.