### PR TITLE
Fix cgram-viewer RGB display values

### DIFF
--- a/bsnes/ui-qt/debugger/ppu/cgram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-viewer.cpp
@@ -62,9 +62,9 @@ void CgramViewer::refresh() {
     text << "<table>";
     text << "<tr><td>Index:</td><td>" << selected << "</td></tr>";
     text << "<tr><td>Value:</td><td>0x" << hex<4>(color) << "</td></tr>";
-    text << "<tr><td>Red:</td><td>" << (unsigned)(r >> 3) << "</td></tr>";
-    text << "<tr><td>Green:</td><td>" << (unsigned)(g >> 3) << "</td></tr>";
-    text << "<tr><td>Blue:</td><td>" << (unsigned)(b >> 3) << "</td></tr>";
+    text << "<tr><td>Red:</td><td>" << (unsigned)r << "</td></tr>";
+    text << "<tr><td>Green:</td><td>" << (unsigned)g << "</td></tr>";
+    text << "<tr><td>Blue:</td><td>" << (unsigned)b << "</td></tr>";
     text << "</table>";
   }
   colorInfo->setText(text);


### PR DESCRIPTION
Used to display color values shifted right by 3, now displays the correct
5-bit values.