### PR TITLE
Updates to the Tilemap Viewer

### DIFF
--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -15,6 +15,7 @@ Debugger *debugger;
 #include "tools/properties.cpp"
 
 #include "ppu/cgram-widget.cpp"
+#include "ppu/image-grid-widget.cpp"
 #include "ppu/tilemap-renderer.cpp"
 
 #include "ppu/vram-viewer.cpp"

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -38,6 +38,7 @@ void ImageGridWidget::setImage(const QImage& image) {
 
 void ImageGridWidget::setZoom(unsigned z) {
   if(z == 0) z = 1;
+  zoom = z;
 
   resetTransform();
   scale(z, z);
@@ -139,19 +140,18 @@ void ImageGridWidget::drawSelectedCell(QPainter* painter, const QRectF&) {
 
   painter->save();
 
+  qreal onePx = 1.0 / zoom;
+
   QRectF cell(selectedCell.x() * gridSize, selectedCell.y() * gridSize,
               gridSize, gridSize);
-  cell = painter->combinedTransform().mapRect(cell);
 
   painter->setBrush(QBrush());
 
-  painter->resetTransform();
-
-  painter->setPen(QPen(SELECTED_INNER_COLOR, 1));
+  painter->setPen(QPen(SELECTED_INNER_COLOR, onePx));
   painter->drawRect(cell);
 
-  cell.adjust(-1, -1, 1, 1);
-  painter->setPen(QPen(SELECTED_OUTER_COLOR, 1));
+  cell.adjust(-onePx, -onePx, onePx, onePx);
+  painter->setPen(QPen(SELECTED_OUTER_COLOR, onePx));
   painter->drawRect(cell);
 
   painter->restore();

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -1,0 +1,87 @@
+#include "image-grid-widget.moc"
+
+const QColor ImageGridWidget::GRID_COLOR = QColor(200, 200, 255, 128);
+
+ImageGridWidget::ImageGridWidget() {
+  pixmap = QPixmap();
+
+  scene = new QGraphicsScene;
+
+  scenePixmap = new QGraphicsPixmapItem();
+  scenePixmap->setTransformationMode(Qt::FastTransformation);
+  scene->addItem(scenePixmap);
+
+  this->setScene(scene);
+
+  showGrid = false;
+  gridSize = 8;
+
+  setZoom(1);
+}
+
+void ImageGridWidget::setImage(const QImage& image) {
+  pixmap.convertFromImage(image);
+  scenePixmap->setPixmap(pixmap);
+  scene->setSceneRect(scenePixmap->boundingRect());
+}
+
+void ImageGridWidget::setZoom(unsigned z) {
+  if(z == 0) z = 1;
+
+  resetTransform();
+  scale(z, z);
+
+  scene->setSceneRect(scenePixmap->boundingRect());
+}
+
+void ImageGridWidget::setGridSize(unsigned g) {
+  if(g == 0) g = 8;
+
+  if(g != gridSize) {
+    gridSize = g;
+
+    viewport()->update();
+  }
+}
+
+void ImageGridWidget::setShowGrid(bool s) {
+  if(showGrid != s) {
+    showGrid = s;
+
+    viewport()->update();
+  }
+}
+
+void ImageGridWidget::drawForeground(QPainter* painter, const QRectF& rect) {
+  if(!showGrid) return;
+
+  QRectF sceneRect = scene->sceneRect();
+
+  qreal top = rect.top() - 1;
+  if(top < 0) top = 0;
+
+  qreal bottom = rect.bottom() + 1;
+  if(bottom > sceneRect.bottom()) bottom = sceneRect.bottom();
+
+  qreal left = rect.left() - 1;
+  if(left < 0) left = 0;
+
+  qreal right = rect.right() + 1;
+  if(right > sceneRect.right()) right = sceneRect.right();
+
+  qreal yStart = int(top) + (gridSize - (int(top) % gridSize));
+  qreal xStart = int(left) + (gridSize - (int(left) % gridSize));
+
+  painter->save();
+  painter->setPen(QPen(GRID_COLOR));
+
+  for(qreal y = yStart; y < bottom; y += gridSize) {
+    painter->drawLine(left, y, right, y);
+  }
+  for(qreal x = xStart; x < right; x += gridSize) {
+     painter->drawLine(x, top, x, bottom);
+  }
+
+  painter->restore();
+}
+

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -1,6 +1,8 @@
 #include "image-grid-widget.moc"
 
 const QColor ImageGridWidget::GRID_COLOR = QColor(200, 200, 255, 128);
+const QColor ImageGridWidget::SELECTED_INNER_COLOR = QColor(255, 255, 255, 255);
+const QColor ImageGridWidget::SELECTED_OUTER_COLOR = QColor(0, 0, 0, 255);
 
 ImageGridWidget::ImageGridWidget() {
   pixmap = QPixmap();
@@ -17,6 +19,15 @@ ImageGridWidget::ImageGridWidget() {
   gridSize = 8;
 
   setZoom(1);
+  selectNone();
+}
+
+QPoint ImageGridWidget::selected() const {
+  return selectedCell;
+}
+
+bool ImageGridWidget::selectionValid() const {
+  return pixmap.rect().contains(selectedCell * int(gridSize));
 }
 
 void ImageGridWidget::setImage(const QImage& image) {
@@ -52,7 +63,45 @@ void ImageGridWidget::setShowGrid(bool s) {
   }
 }
 
+void ImageGridWidget::selectNone() {
+  bool previouslyValid = selectionValid();
+
+  selectedCell = QPoint(-1, -1);
+
+  if(previouslyValid) {
+    viewport()->update();
+    selectedChanged();
+  }
+}
+
+void ImageGridWidget::setSelected(const QPoint& cell) {
+  if(selectedCell != cell) {
+    selectedCell = cell;
+
+    viewport()->update();
+    selectedChanged();
+  }
+}
+
+void ImageGridWidget::mousePressEvent(QMouseEvent* event) {
+  if(event->button() != Qt::LeftButton) return;
+
+  QPoint p = mapToScene(event->pos()).toPoint();
+  QPoint c(p.x() / gridSize, p.y() / gridSize);
+
+  if(p.x() > 0 && p.y() > 0 && pixmap.rect().contains(c)) {
+    setSelected(c);
+  } else {
+    selectNone();
+  }
+}
+
 void ImageGridWidget::drawForeground(QPainter* painter, const QRectF& rect) {
+  drawGrid(painter, rect);
+  drawSelectedCell(painter, rect);
+}
+
+void ImageGridWidget::drawGrid(QPainter* painter, const QRectF& rect) {
   if(!showGrid) return;
 
   QRectF sceneRect = scene->sceneRect();
@@ -85,3 +134,25 @@ void ImageGridWidget::drawForeground(QPainter* painter, const QRectF& rect) {
   painter->restore();
 }
 
+void ImageGridWidget::drawSelectedCell(QPainter* painter, const QRectF&) {
+  if(!selectionValid()) return;
+
+  painter->save();
+
+  QRectF cell(selectedCell.x() * gridSize, selectedCell.y() * gridSize,
+              gridSize, gridSize);
+  cell = painter->combinedTransform().mapRect(cell);
+
+  painter->setBrush(QBrush());
+
+  painter->resetTransform();
+
+  painter->setPen(QPen(SELECTED_INNER_COLOR, 1));
+  painter->drawRect(cell);
+
+  cell.adjust(-1, -1, 1, 1);
+  painter->setPen(QPen(SELECTED_OUTER_COLOR, 1));
+  painter->drawRect(cell);
+
+  painter->restore();
+}

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -123,7 +123,7 @@ void ImageGridWidget::drawGrid(QPainter* painter, const QRectF& rect) {
   qreal xStart = int(left) + (gridSize - (int(left) % gridSize));
 
   painter->save();
-  painter->setPen(QPen(GRID_COLOR));
+  painter->setPen(QPen(GRID_COLOR, 1.0 / zoom));
 
   for(qreal y = yStart; y < bottom; y += gridSize) {
     painter->drawLine(left, y, right, y);

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
@@ -36,6 +36,7 @@ private:
 
 private:
   bool showGrid;
+  unsigned zoom;
   unsigned gridSize;
 
   QPoint selectedCell;

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
@@ -1,0 +1,29 @@
+
+class ImageGridWidget : public QGraphicsView {
+  Q_OBJECT
+
+  const static QColor GRID_COLOR;
+
+public:
+  ImageGridWidget();
+
+  void setImage(const QImage& image);
+  void setZoom(unsigned zoom);
+  void setGridSize(unsigned gridSize);
+
+public slots:
+  void setShowGrid(bool showGrid);
+
+protected:
+  void drawForeground(QPainter* painter, const QRectF& rect);
+
+private:
+  bool showGrid;
+  unsigned gridSize;
+
+  QPixmap pixmap;
+
+  QGraphicsScene *scene;
+  QGraphicsPixmapItem *scenePixmap;
+};
+

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
@@ -3,6 +3,8 @@ class ImageGridWidget : public QGraphicsView {
   Q_OBJECT
 
   const static QColor GRID_COLOR;
+  const static QColor SELECTED_INNER_COLOR;
+  const static QColor SELECTED_OUTER_COLOR;
 
 public:
   ImageGridWidget();
@@ -11,15 +13,32 @@ public:
   void setZoom(unsigned zoom);
   void setGridSize(unsigned gridSize);
 
+  QPoint selected() const;
+  bool selectionValid() const;
+
 public slots:
   void setShowGrid(bool showGrid);
 
+  void selectNone();
+  void setSelected(const QPoint& cell);
+
+signals:
+  void selectedChanged();
+
 protected:
+  void mousePressEvent(QMouseEvent *event);
+
   void drawForeground(QPainter* painter, const QRectF& rect);
+
+private:
+  void drawGrid(QPainter* painter, const QRectF& rect);
+  void drawSelectedCell(QPainter* painter, const QRectF& rect);
 
 private:
   bool showGrid;
   unsigned gridSize;
+
+  QPoint selectedCell;
 
   QPixmap pixmap;
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
@@ -34,6 +34,14 @@ unsigned TilemapRenderer::nLayersInMode() const {
   return layers[screenMode & 7];
 }
 
+unsigned TilemapRenderer::tileSizePx() const {
+  if(bitDepth != BitDepth::MODE7) {
+    return tileSize ? 16 : 8;
+  } else {
+    return 8;
+  }
+}
+
 void TilemapRenderer::loadScreenMode() {
   screenMode = SNES::ppu.bg_mode() & 7;
 }

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -22,6 +22,7 @@ public:
   void loadTilemapSettings();
 
   unsigned nLayersInMode() const;
+  unsigned tileSizePx() const;
 
   void buildPalette();
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -210,11 +210,13 @@ void TilemapViewer::updateForm() {
   }
 
   bool ct = customTilemap->isChecked();
+  bool mode7 = renderer.bitDepth == TilemapRenderer::MODE7;
+
   bitDepth->setEnabled(ct);
-  screenAddr->setEnabled(ct);
-  tileAddr->setEnabled(ct);
-  screenSize->setEnabled(ct);
-  tileSize->setEnabled(ct);
+  screenAddr->setEnabled(ct & !mode7);
+  tileAddr->setEnabled(ct & !mode7);
+  screenSize->setEnabled(ct & !mode7);
+  tileSize->setEnabled(ct & !mode7);
 
   if(ct == false) {
     renderer.updateBitDepth();

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -37,8 +37,11 @@ TilemapViewer::TilemapViewer() {
   zoomCombo->addItem("8x", QVariant(8));
   zoomCombo->addItem("9x", QVariant(9));
 
+  showGrid = new QCheckBox("Show Grid");
+  sidebarLayout->addRow(zoomCombo, showGrid);
+
   autoUpdateBox = new QCheckBox("Auto update");
-  sidebarLayout->addRow(zoomCombo, autoUpdateBox);
+  sidebarLayout->addRow("", autoUpdateBox);
 
   refreshButton = new QPushButton("Refresh");
   sidebarLayout->addRow(refreshButton);
@@ -96,15 +99,9 @@ TilemapViewer::TilemapViewer() {
   tileAddr = new QLineEdit;
   sidebarLayout->addRow("Tile Addr:", tileAddr);
 
-  scene = new QGraphicsScene;
-
-  scenePixmap = new QGraphicsPixmapItem();
-  scenePixmap->setTransformationMode(Qt::FastTransformation);
-  scene->addItem(scenePixmap);
-
-  view = new QGraphicsView(scene);
-  view->setMinimumSize(256, 256);
-  layout->addWidget(view, 10);
+  imageGridWidget = new ImageGridWidget();
+  imageGridWidget->setMinimumSize(256, 256);
+  layout->addWidget(imageGridWidget, 10);
 
 
   updateForm();
@@ -112,6 +109,7 @@ TilemapViewer::TilemapViewer() {
 
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
   connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
+  connect(showGrid,      SIGNAL(clicked(bool)), imageGridWidget, SLOT(setShowGrid(bool)));
 
   connect(customScreenMode, SIGNAL(clicked(bool)), this, SLOT(refresh()));
   connect(customTilemap,    SIGNAL(clicked(bool)), this, SLOT(refresh()));
@@ -146,20 +144,14 @@ void TilemapViewer::refresh() {
     renderer.buildPalette();
 
     QImage image = renderer.drawTilemap();
-    scenePixmap->setPixmap(QPixmap::fromImage(image));
-
-    scene->setSceneRect(scenePixmap->boundingRect());
+    imageGridWidget->setImage(image);
+    imageGridWidget->setGridSize(renderer.tileSizePx());
   }
 }
 
 void TilemapViewer::onZoomChanged(int index) {
   unsigned z = zoomCombo->itemData(index).toUInt();
-  if(z == 0) z = 1;
-
-  view->resetTransform();
-  view->scale(z, z);
-
-  scene->setSceneRect(scenePixmap->boundingRect());
+  imageGridWidget->setZoom(z);
 }
 
 void TilemapViewer::updateRendererSettings() {

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -15,6 +15,9 @@ public slots:
 private:
   void updateRendererSettings();
   void updateForm();
+  void updateTileInfo();
+  void updateTileInfoNormal();
+  void updateTileInfoMode7();
 
 private:
   TilemapRenderer renderer;
@@ -39,6 +42,8 @@ private:
   QComboBox *tileSize;
   QLineEdit *tileAddr;
   QLineEdit *screenAddr;
+
+  QLabel *tileInfo;
 
   ImageGridWidget* imageGridWidget;
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -25,7 +25,9 @@ private:
 
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
+
   QComboBox *zoomCombo;
+  QCheckBox *showGrid;
 
   QCheckBox *customScreenMode;
   QCheckBox *customTilemap;
@@ -38,10 +40,7 @@ private:
   QLineEdit *tileAddr;
   QLineEdit *screenAddr;
 
-  QGraphicsScene *scene;
-  QGraphicsPixmapItem *scenePixmap;
-
-  QGraphicsView* view;
+  ImageGridWidget* imageGridWidget;
 
   bool inUpdateFormCall;
 };

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -11,11 +11,10 @@ public slots:
   void refresh();
 
   void onZoomChanged(int);
-  void onFormChanged();
-  void updateForm();
 
-  void setCustomScreenMode(bool);
-  void setCustomTilemap(bool);
+private:
+  void updateRendererSettings();
+  void updateForm();
 
 private:
   TilemapRenderer renderer;

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -49,6 +49,7 @@ using namespace ruby;
   #include "debugger/tools/properties.moc.hpp"
 
   #include "debugger/ppu/cgram-widget.moc.hpp"
+  #include "debugger/ppu/image-grid-widget.moc.hpp"
   #include "debugger/ppu/tilemap-renderer.hpp"
 
   #include "debugger/ppu/vram-viewer.moc.hpp"


### PR DESCRIPTION
This pull request adds an optional grid, tile selection and tile properties to the Tilemap Viewer.

Like my previous pull requests it will need to be tested on OSX (paging @Optiroc) and Windows 10 to ensure there are no glitches but I am not expecting any.

Tile properties (Secret of Evermore)
![secret-of-evermore](https://cloud.githubusercontent.com/assets/65687/24040849/af2ac232-0b56-11e7-8184-8dbd71957724.png)

Mode 7 Tile Property (Illusion of Gaia)
![illusion-of-gaia](https://cloud.githubusercontent.com/assets/65687/24040848/a885cd8c-0b56-11e7-8ef0-785e9e765e7d.png)
