### PR TITLE
Fix debugger graphical glitches

### DIFF
--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -60,8 +60,10 @@ void CgramWidget::paintEvent(QPaintEvent*) {
   painter.drawImage(0, 0, image->scaled(image->width() * scale, image->height() * scale, Qt::IgnoreAspectRatio, Qt::FastTransformation));
 
   if(selected >= 0 && selected < 256) {
-    const static QPen white(Qt::white, 1, Qt::SolidLine);
-    const static QPen black(Qt::black, 1, Qt::DashLine);
+    QPen white(Qt::white, 1, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
+
+    QPen black(Qt::black, 1, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
+    black.setDashPattern({ 2.0, 2.0 });
 
     painter.resetTransform();
 

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -141,18 +141,25 @@ void ImageGridWidget::drawSelectedCell(QPainter* painter, const QRectF&) {
 
   painter->save();
 
-  qreal onePx = 1.0 / zoom;
-
   QRectF cell(selectedCell.x() * gridSize, selectedCell.y() * gridSize,
               gridSize, gridSize);
 
+  cell = painter->worldTransform().mapRect(cell);
+
+  painter->resetTransform();
+
   painter->setBrush(QBrush());
 
-  painter->setPen(cosmeticPen(SELECTED_INNER_COLOR));
+  QPen innerPen = cosmeticPen(SELECTED_INNER_COLOR);
+  innerPen.setJoinStyle(Qt::MiterJoin);
+  painter->setPen(innerPen);
   painter->drawRect(cell);
 
-  cell.adjust(-onePx, -onePx, onePx, onePx);
-  painter->setPen(cosmeticPen(SELECTED_OUTER_COLOR));
+  cell.adjust(-1, -1, 1, 1);
+
+  QPen outerPen = cosmeticPen(SELECTED_OUTER_COLOR);
+  outerPen.setJoinStyle(Qt::MiterJoin);
+  painter->setPen(outerPen);
   painter->drawRect(cell);
 
   painter->restore();

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -123,7 +123,8 @@ void ImageGridWidget::drawGrid(QPainter* painter, const QRectF& rect) {
   qreal xStart = int(left) + (gridSize - (int(left) % gridSize));
 
   painter->save();
-  painter->setPen(QPen(GRID_COLOR, 1.0 / zoom));
+
+  painter->setPen(cosmeticPen(GRID_COLOR));
 
   for(qreal y = yStart; y < bottom; y += gridSize) {
     painter->drawLine(left, y, right, y);
@@ -147,12 +148,27 @@ void ImageGridWidget::drawSelectedCell(QPainter* painter, const QRectF&) {
 
   painter->setBrush(QBrush());
 
-  painter->setPen(QPen(SELECTED_INNER_COLOR, onePx));
+  painter->setPen(cosmeticPen(SELECTED_INNER_COLOR));
   painter->drawRect(cell);
 
   cell.adjust(-onePx, -onePx, onePx, onePx);
-  painter->setPen(QPen(SELECTED_OUTER_COLOR, onePx));
+  painter->setPen(cosmeticPen(SELECTED_OUTER_COLOR));
   painter->drawRect(cell);
 
   painter->restore();
+}
+
+QPen ImageGridWidget::cosmeticPen(const QColor& color) const {
+#if QT_VERSION >= 0x050600
+    qreal pixelRatio = devicePixelRatioF();
+#elif QT_VERSION >= 0x050000
+    int pixelRatio = devicePixelRatio();
+#else
+    int pixelRatio = 1;
+#endif
+
+  QPen pen(color, pixelRatio);
+  pen.setCosmetic(true);
+
+  return pen;
 }

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
@@ -34,6 +34,8 @@ private:
   void drawGrid(QPainter* painter, const QRectF& rect);
   void drawSelectedCell(QPainter* painter, const QRectF& rect);
 
+  QPen cosmeticPen(const QColor& color) const;
+
 private:
   bool showGrid;
   unsigned zoom;


### PR DESCRIPTION
This pull request fixes two graphical issues with ImageGridWidget and CgramWidget that I noticed in @Optiroc's Qt5 branch of bsnes-plus.

I'm adding the code to bsnes-plus master as the new code is neater and works on Qt4.

<br/>

This pull request has been tested on:
 * Qt 4.8.7 / ArchLinux x64
 * Qt 4.8.6-1 mingw x86 / Windows 7

And on the Qt5 branch:
 * Qt 5.8.0 / ArchLinux x64
 * Qt 5.9.0 / ArchLinux x64
 * Qt 5.5.0 mingw x86 / Windows 7
 * Qt 5.8.0 mingw x86 / Windows 7
 * Qt 5.9.0 mingw x86 / Windows 7
 * Qt 5.9.0 mingw x86 / Windows 10 with a multi-monitor hi-dpi setup.

---

Glitch 1:
Some ImageGridWidget selected cells are rendered incorrectly on my machine if the zoom setting is prime:
![qt5-glitched-tilemap](https://user-images.githubusercontent.com/65687/26970449-cdabac34-4d4c-11e7-8079-349f3f3b859f.png)

Fixed:
![qt5-tilemap-fixed](https://user-images.githubusercontent.com/65687/26971995-0958df58-4d53-11e7-9749-0b97c7b490f3.png)


Glitch 2:
Selected colour outline in CgramWidget outline looks wrong when QT_SCALE_FACTOR != 1.
![qt5-glitched-cgram](https://user-images.githubusercontent.com/65687/26971286-e5f108ea-4d4f-11e7-9481-d18e3acf8e0b.png)

Fixed:
![qt5-fixed-cgram](https://user-images.githubusercontent.com/65687/26970483-e5360f8e-4d4c-11e7-86e1-6e92ae181e66.png)

