### PR TITLE
More PPU debugger updates

### DIFF
--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return regs.oam_basesize; 
 }
 
+bool PPUDebugger::mode7_extbg() const {
+  return regs.mode7_extbg;
+}
+
 bool PPUDebugger::property(unsigned id, string &name, string &value) {
   unsigned n = 0;
 

--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.hpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.hpp
@@ -16,5 +16,6 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return oam.regs.base_size; 
 }
 
+bool PPUDebugger::mode7_extbg() const {
+  return regs.mode7_extbg;
+}
+
 bool PPUDebugger::property(unsigned id, string &name, string &value) {
   unsigned n = 0;
 

--- a/bsnes/snes/alt/ppu-performance/debugger/debugger.hpp
+++ b/bsnes/snes/alt/ppu-performance/debugger/debugger.hpp
@@ -16,5 +16,6 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/snes/ppu/debugger/debugger.cpp
+++ b/bsnes/snes/ppu/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return oam.regs.base_size; 
 }
 
+bool PPUDebugger::mode7_extbg() const {
+  return regs.mode7_extbg;
+}
+
 bool PPUDebugger::property(unsigned id, string &name, string &value) {
   unsigned n = 0;
 

--- a/bsnes/snes/ppu/debugger/debugger.hpp
+++ b/bsnes/snes/ppu/debugger/debugger.hpp
@@ -16,5 +16,6 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -142,6 +142,7 @@ Configuration::Configuration() {
   attach(geometry.propertiesViewer = "", "geometry.propertiesViewer");
   attach(geometry.layerToggle      = "", "geometry.layerToggle");
   attach(geometry.vramViewer       = "", "geometry.vramViewer");
+  attach(geometry.tileViewer       = "", "geometry.tileViewer");
   attach(geometry.tilemapViewer    = "", "geometry.tilemapViewer");
   attach(geometry.oamViewer        = "", "geometry.oamViewer");
   attach(geometry.cgramViewer      = "", "geometry.cgramViewer");

--- a/bsnes/ui-qt/config.hpp
+++ b/bsnes/ui-qt/config.hpp
@@ -99,6 +99,7 @@ public:
     string propertiesViewer;
     string layerToggle;
     string vramViewer;
+    string tileViewer;
     string tilemapViewer;
     string oamViewer;
     string cgramViewer;

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -15,12 +15,14 @@ Debugger *debugger;
 #include "tools/properties.cpp"
 
 #include "ppu/base-renderer.cpp"
+#include "ppu/tile-renderer.cpp"
 #include "ppu/tilemap-renderer.cpp"
 
 #include "ppu/cgram-widget.cpp"
 #include "ppu/image-grid-widget.cpp"
 
 #include "ppu/vram-viewer.cpp"
+#include "ppu/tile-viewer.cpp"
 #include "ppu/tilemap-viewer.cpp"
 #include "ppu/oam-viewer.cpp"
 #include "ppu/cgram-viewer.cpp"
@@ -49,6 +51,7 @@ Debugger::Debugger() {
 
   menu_ppu = menu->addMenu("S-PPU");
   menu_ppu_vramViewer = menu_ppu->addAction("Video RAM Viewer ...");
+  menu_ppu_tileViewer = menu_ppu->addAction("Tile Viewer ...");
   menu_ppu_tilemapViewer = menu_ppu->addAction("Tilemap Viewer ...");
   menu_ppu_oamViewer = menu_ppu->addAction("Sprite Viewer ...");
   menu_ppu_cgramViewer = menu_ppu->addAction("Palette Viewer ...");
@@ -159,6 +162,7 @@ Debugger::Debugger() {
   memoryEditor = new MemoryEditor;
   propertiesViewer = new PropertiesViewer;
   vramViewer = new VramViewer;
+  tileViewer = new TileViewer;
   tilemapViewer = new TilemapViewer;
   oamViewer = new OamViewer;
   cgramViewer = new CgramViewer;
@@ -170,6 +174,7 @@ Debugger::Debugger() {
   connect(menu_tools_propertiesViewer, SIGNAL(triggered()), propertiesViewer, SLOT(show()));
 
   connect(menu_ppu_vramViewer, SIGNAL(triggered()), vramViewer, SLOT(show()));
+  connect(menu_ppu_tileViewer, SIGNAL(triggered()), tileViewer, SLOT(show()));
   connect(menu_ppu_tilemapViewer, SIGNAL(triggered()), tilemapViewer, SLOT(show()));
   connect(menu_ppu_oamViewer, SIGNAL(triggered()), oamViewer, SLOT(show()));
   connect(menu_ppu_cgramViewer, SIGNAL(triggered()), cgramViewer, SLOT(show()));
@@ -494,6 +499,7 @@ void Debugger::autoUpdate() {
   memoryEditor->autoUpdate();
   propertiesViewer->autoUpdate();
   vramViewer->autoUpdate();
+  tileViewer->autoUpdate();
   tilemapViewer->autoUpdate();
   oamViewer->autoUpdate();
   cgramViewer->autoUpdate();

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -14,9 +14,11 @@ Debugger *debugger;
 #include "tools/memory.cpp"
 #include "tools/properties.cpp"
 
+#include "ppu/base-renderer.cpp"
+#include "ppu/tilemap-renderer.cpp"
+
 #include "ppu/cgram-widget.cpp"
 #include "ppu/image-grid-widget.cpp"
-#include "ppu/tilemap-renderer.cpp"
 
 #include "ppu/vram-viewer.cpp"
 #include "ppu/tilemap-viewer.cpp"

--- a/bsnes/ui-qt/debugger/debugger.moc.hpp
+++ b/bsnes/ui-qt/debugger/debugger.moc.hpp
@@ -10,6 +10,7 @@ public:
   QAction *menu_tools_propertiesViewer;
   QMenu *menu_ppu;
   QAction *menu_ppu_vramViewer;
+  QAction *menu_ppu_tileViewer;
   QAction *menu_ppu_tilemapViewer;
   QAction *menu_ppu_oamViewer;
   QAction *menu_ppu_cgramViewer;

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
@@ -15,10 +15,14 @@ BaseRenderer::BitDepth BaseRenderer::bitDepthForLayer(unsigned screenMode, unsig
     { BPP8, BPP2, NONE, NONE},
     { BPP4, BPP2, NONE, NONE},
     { BPP4, NONE, NONE, NONE},
-    { MODE7, MODE7, MODE7, MODE7}
+    { MODE7, MODE7_EXTBG, NONE, NONE}
   };
 
   return map[screenMode & 7][layer & 3];
+}
+
+bool BaseRenderer::isMode7() const {
+    return bitDepth == BitDepth::MODE7 || bitDepth == BitDepth::MODE7_EXTBG;
 }
 
 unsigned BaseRenderer::bytesInbetweenTiles() const {
@@ -27,6 +31,7 @@ unsigned BaseRenderer::bytesInbetweenTiles() const {
     case BitDepth::BPP4: return 32;
     case BitDepth::BPP2: return 16;
     case BitDepth::MODE7: return 128;
+    case BitDepth::MODE7_EXTBG: return 128;
   }
   return 0;
 }
@@ -37,6 +42,7 @@ unsigned BaseRenderer::colorsPerTile() const {
     case BitDepth::BPP4: return 16;
     case BitDepth::BPP2: return 4;
     case BitDepth::MODE7: return 256;
+    case BitDepth::MODE7_EXTBG: return 256;
   }
   return 0;
 }
@@ -128,7 +134,10 @@ void BaseRenderer::draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, c
 void BaseRenderer::drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* tile) {
   for(unsigned py = 0; py < 8; py++) {
     for(unsigned px = 0; px < 8; px++) {
-      if(*tile != 0) imgBits[px] = palette[*tile];
+      uint8_t pixel = *tile;
+      if(bitDepth == MODE7_EXTBG) pixel &= 0x7f;
+
+      if(pixel != 0) imgBits[px] = palette[pixel];
       tile +=2;
     }
     imgBits += wordsPerScanline;

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
@@ -6,6 +6,26 @@ BaseRenderer::BaseRenderer()
   overrideBackgroundColor = false;
 }
 
+unsigned BaseRenderer::bytesInbetweenTiles() const {
+  switch (bitDepth) {
+    case BitDepth::BPP8: return 64;
+    case BitDepth::BPP4: return 32;
+    case BitDepth::BPP2: return 16;
+    case BitDepth::MODE7: return 128;
+  }
+  return 0;
+}
+
+unsigned BaseRenderer::colorsPerTile() const {
+  switch (bitDepth) {
+    case BitDepth::BPP8: return 256;
+    case BitDepth::BPP4: return 16;
+    case BitDepth::BPP2: return 4;
+    case BitDepth::MODE7: return 256;
+  }
+  return 0;
+}
+
 void BaseRenderer::buildPalette() {
   if(SNES::cartridge.loaded()) {
     for(unsigned i = 0; i < 256; i++) {

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
@@ -1,0 +1,101 @@
+
+BaseRenderer::BaseRenderer()
+{
+  customBackgroundColor = 0;
+  bitDepth = BitDepth::NONE;
+  overrideBackgroundColor = false;
+}
+
+void BaseRenderer::buildPalette() {
+  if(SNES::cartridge.loaded()) {
+    for(unsigned i = 0; i < 256; i++) {
+      palette[i] = rgbFromCgram(i);
+    }
+  }
+}
+
+void BaseRenderer::initImage(unsigned width, unsigned height)
+{
+  QImage::Format format = QImage::Format_RGB32;
+  if(overrideBackgroundColor) {
+    if(qAlpha(customBackgroundColor) != 0xff) format = QImage::Format_ARGB32;
+    if(customBackgroundColor == 0) format = QImage::Format_ARGB32_Premultiplied;
+  }
+
+  if(image.width() != width || image.height() != height || image.format() != format) {
+    image = QImage(width, height, format);
+  }
+
+  if(overrideBackgroundColor) {
+    image.fill(customBackgroundColor);
+  } else {
+    image.fill(palette[0]);
+  }
+}
+
+void BaseRenderer::invalidateImage()
+{
+  image = QImage();
+}
+
+void BaseRenderer::draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* tile, unsigned palOffset, bool hFlip, bool vFlip) {
+  uint8_t data[8];
+
+  for(unsigned py = 0; py < 8; py++) {
+    unsigned fpy = (vFlip == false) ? py : 7 - py;
+    const uint8_t *sliver = tile + fpy * 2;
+
+    switch(bitDepth) {
+    case BitDepth::BPP8:
+      data[4] = sliver[32];
+      data[5] = sliver[33];
+      data[6] = sliver[48];
+      data[7] = sliver[49];
+      //fall through
+    case BitDepth::BPP4:
+      data[2] = sliver[16];
+      data[3] = sliver[17];
+      //fall through
+    case BitDepth::BPP2:
+      data[0] = sliver[ 0];
+      data[1] = sliver[ 1];
+    }
+
+    for(unsigned px = 0; px < 8; px++) {
+      unsigned fpx = hFlip == false ? px : 7 - px;
+
+      uint8_t pixel = 0;
+      switch(bitDepth) {
+      case BitDepth::BPP8:
+        pixel |= (data[7] & (0x80 >> px)) ? 0x80 : 0;
+        pixel |= (data[6] & (0x80 >> px)) ? 0x40 : 0;
+        pixel |= (data[5] & (0x80 >> px)) ? 0x20 : 0;
+        pixel |= (data[4] & (0x80 >> px)) ? 0x10 : 0;
+        //fall through
+      case BitDepth::BPP4:
+        pixel |= (data[3] & (0x80 >> px)) ? 0x08 : 0;
+        pixel |= (data[2] & (0x80 >> px)) ? 0x04 : 0;
+        //fall through
+      case BitDepth::BPP2:
+        pixel |= (data[1] & (0x80 >> px)) ? 0x02 : 0;
+        pixel |= (data[0] & (0x80 >> px)) ? 0x01 : 0;
+      }
+
+      if (pixel != 0) {
+        imgBits[fpx] = palette[(palOffset + pixel) & 0xff];
+      }
+    }
+
+    imgBits += wordsPerScanline;
+  }
+}
+
+void BaseRenderer::drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* tile) {
+  for(unsigned py = 0; py < 8; py++) {
+    for(unsigned px = 0; px < 8; px++) {
+      if(*tile != 0) imgBits[px] = palette[*tile];
+      tile +=2;
+    }
+    imgBits += wordsPerScanline;
+  }
+}

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.cpp
@@ -6,6 +6,21 @@ BaseRenderer::BaseRenderer()
   overrideBackgroundColor = false;
 }
 
+BaseRenderer::BitDepth BaseRenderer::bitDepthForLayer(unsigned screenMode, unsigned layer) {
+  static const BitDepth map[8][4] = {
+    { BPP2, BPP2, BPP2, BPP2},
+    { BPP4, BPP4, BPP2, NONE},
+    { BPP4, BPP4, NONE, NONE},
+    { BPP8, BPP4, NONE, NONE},
+    { BPP8, BPP2, NONE, NONE},
+    { BPP4, BPP2, NONE, NONE},
+    { BPP4, NONE, NONE, NONE},
+    { MODE7, MODE7, MODE7, MODE7}
+  };
+
+  return map[screenMode & 7][layer & 3];
+}
+
 unsigned BaseRenderer::bytesInbetweenTiles() const {
   switch (bitDepth) {
     case BitDepth::BPP8: return 64;

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
@@ -1,5 +1,5 @@
 struct BaseRenderer {
-  enum BitDepth { BPP8, BPP4, BPP2, MODE7, NONE };
+  enum BitDepth { BPP8, BPP4, BPP2, MODE7, MODE7_EXTBG, NONE };
 
   QRgb customBackgroundColor;
   QRgb palette[256];
@@ -11,6 +11,8 @@ struct BaseRenderer {
 
 public:
   BaseRenderer();
+
+  bool isMode7() const;
 
   unsigned bytesInbetweenTiles() const;
   unsigned colorsPerTile() const;

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
@@ -15,6 +15,8 @@ public:
   unsigned bytesInbetweenTiles() const;
   unsigned colorsPerTile() const;
 
+  static BitDepth bitDepthForLayer(unsigned screenMode, unsigned layer);
+
 protected:
   void buildPalette();
 

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
@@ -12,6 +12,9 @@ struct BaseRenderer {
 public:
   BaseRenderer();
 
+  unsigned bytesInbetweenTiles() const;
+  unsigned colorsPerTile() const;
+
 protected:
   void buildPalette();
 

--- a/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/base-renderer.hpp
@@ -1,0 +1,24 @@
+struct BaseRenderer {
+  enum BitDepth { BPP8, BPP4, BPP2, MODE7, NONE };
+
+  QRgb customBackgroundColor;
+  QRgb palette[256];
+  QImage image;
+
+  BitDepth bitDepth;
+
+  bool overrideBackgroundColor;
+
+public:
+  BaseRenderer();
+
+protected:
+  void buildPalette();
+
+  void initImage(unsigned width, unsigned height);
+  void invalidateImage();
+
+  void draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* tile, unsigned palOffset, bool hFlip, bool vFlip);
+
+  void drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* tile);
+};

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -17,8 +17,12 @@ void CgramWidget::setScale(unsigned s) {
 
 void CgramWidget::setPaletteBpp(unsigned bpp) {
   if(bpp > 8) bpp = 0;
+  setPaletteSize(1 << bpp);
+}
 
-  unsigned nColors = 1 << bpp;
+void CgramWidget::setPaletteSize(unsigned nColors) {
+  if(nColors < 1) nColors = 1;
+  if(nColors > 256) nColors = 256;
 
   selectedMask = 0xff - nColors + 1;
   selectedWidth = (nColors - 1) % 16 + 1;

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -100,7 +100,7 @@ void CgramWidget::refresh() {
     return;
   }
 
-  uint32_t *buffer = (uint32_t*)image->bits();
+  QRgb* buffer = (QRgb*)image->bits();
 
   for(unsigned i = 0; i < 256; i++) {
     buffer[i] = rgbFromCgram(i);
@@ -109,7 +109,7 @@ void CgramWidget::refresh() {
   update();
 }
 
-uint32_t rgbFromCgram(unsigned i) {
+QRgb rgbFromCgram(unsigned i) {
   uint16_t color = SNES::memory::cgram[i * 2 + 0];
   color |= SNES::memory::cgram[i * 2 + 1] << 8;
 
@@ -121,5 +121,5 @@ uint32_t rgbFromCgram(unsigned i) {
   g = (g << 3) | (g >> 2);
   b = (b << 3) | (b >> 2);
 
-  return (r << 16) | (g << 8) | (b << 0);
+  return qRgb(r, g, b);
 }

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
@@ -34,4 +34,4 @@ private:
   unsigned selectedHeight;
 };
 
-uint32_t rgbFromCgram(unsigned);
+QRgb rgbFromCgram(unsigned);

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.moc.hpp
@@ -9,6 +9,7 @@ public:
   void setScale(unsigned);
 
   void setPaletteBpp(unsigned);
+  void setPaletteSize(unsigned);
 
   bool hasSelected() const;
   unsigned selectedPalette() const;

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -84,6 +84,13 @@ void ImageGridWidget::setSelected(const QPoint& cell) {
   }
 }
 
+void ImageGridWidget::scrollToCell(const QPoint& cell) {
+  QPoint p = matrix().map(cell * int(gridSize));
+
+  horizontalScrollBar()->setValue(p.x());
+  verticalScrollBar()->setValue(p.y());
+}
+
 void ImageGridWidget::mousePressEvent(QMouseEvent* event) {
   if(event->button() != Qt::LeftButton) return;
 

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.moc.hpp
@@ -22,6 +22,8 @@ public slots:
   void selectNone();
   void setSelected(const QPoint& cell);
 
+  void scrollToCell(const QPoint& cell);
+
 signals:
   void selectedChanged();
 

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -210,7 +210,7 @@ void OamCanvas::refresh() {
 }
 
 void OamCanvas::refreshImage(const OamObject& obj) {
-  uint32_t palette[16];
+  QRgb palette[16];
   for(unsigned i = 0; i < 16; i++) {
     palette[i] = rgbFromCgram(128 + obj.palette * 16 + i);
   }
@@ -225,7 +225,7 @@ void OamCanvas::refreshImage(const OamObject& obj) {
       const uint8_t* tile = objTileset + cy * 512 + cx * 32;
 
       for(unsigned py = 0; py < 8; py++) {
-        uint32_t *dest = ((uint32_t*)buffer.scanLine(ty * 8 + py)) + tx * 8;
+        QRgb* dest = ((QRgb*)buffer.scanLine(ty * 8 + py)) + tx * 8;
 
         uint8_t d0 = tile[ 0];
         uint8_t d1 = tile[ 1];

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
@@ -34,6 +34,19 @@ unsigned TileRenderer::nTiles() const {
   return (0x10000 - a) / bytesInbetweenTiles();
 }
 
+unsigned TileRenderer::maxAddress() const {
+  switch(source) {
+    case Source::VRAM:     return 64 * 1024;
+    case Source::CPU_BUS:  return 16 * 1024 * 1024;
+    case Source::CART_ROM: return SNES::memory::cartrom.size();
+    case Source::CART_RAM: return SNES::memory::cartram.size();
+    case Source::SA1_BUS:  return SNES::cartridge.has_sa1()    ? 16 * 1024 * 1024 : 0;
+    case Source::SFX_BUS:  return SNES::cartridge.has_superfx() ? 8 * 1024 * 1024 : 0;
+  }
+
+  return 0;
+}
+
 void TileRenderer::buildCgramPalette() {
   const unsigned nColors = colorsPerTile();
 
@@ -75,9 +88,8 @@ void TileRenderer::draw() {
   if(isMode7()) { drawMode7Tileset(); return; }
 
   if(source == Source::VRAM) { drawVramTileset(); return; }
-  if(source == Source::CPU_BUS) { drawCpuBusTiles(); return; }
 
-  invalidateImage();
+  drawMemorySourceTiles();
 }
 
 void TileRenderer::drawVramTileset() {
@@ -139,11 +151,20 @@ void TileRenderer::drawMode7Tileset() {
   }
 }
 
-void TileRenderer::drawCpuBusTiles() {
+void TileRenderer::drawMemorySourceTiles() {
   typedef SNES::Debugger::MemorySource MemorySource;
 
-  source = Source::CPU_BUS;
+  if(source == Source::VRAM) source = Source::CPU_BUS;
   address &= 0xffffff;
+
+  MemorySource memSource = MemorySource::CPUBus;
+  switch(source) {
+    case Source::CPU_BUS:  memSource = MemorySource::CPUBus;  break;
+    case Source::CART_ROM: memSource = MemorySource::CartROM; break;
+    case Source::CART_RAM: memSource = MemorySource::CartRAM; break;
+    case Source::SA1_BUS:  memSource = MemorySource::SA1Bus;  break;
+    case Source::SFX_BUS:  memSource = MemorySource::SFXBus;  break;
+  }
 
   const unsigned height = nTiles() / width;
 
@@ -167,7 +188,7 @@ void TileRenderer::drawCpuBusTiles() {
 
     for(unsigned x = 0; x < width; x++) {
       for(unsigned i = 0; i < bytesPerTile; i++) {
-        tile[i] = SNES::debugger.read(MemorySource::CPUBus, addr);
+        tile[i] = SNES::debugger.read(memSource, addr);
         addr++;
       }
       draw8pxTile(imgBits, wordsPerScanline, tile, 0, 0, 0);

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
@@ -1,0 +1,116 @@
+
+TileRenderer::TileRenderer()
+    : BaseRenderer()
+{
+  bitDepth = BitDepth::BPP4;
+  width = 16;
+
+  paletteOffset = 0;
+  useCgramPalette = false;
+}
+
+unsigned TileRenderer::nTiles() const {
+  switch (bitDepth) {
+    case BitDepth::BPP8: return 1024;
+    case BitDepth::BPP4: return 2048;
+    case BitDepth::BPP2: return 4096;
+    case BitDepth::MODE7: return 256;
+  }
+  return 0;
+}
+
+void TileRenderer::buildCgramPalette() {
+  const unsigned nColors = colorsPerTile();
+
+  paletteOffset &= 0xff;
+
+  unsigned start = paletteOffset & (0xff - nColors + 1);
+  assert(start + nColors < 256);
+
+  for(unsigned i = 0; i < nColors; i++) {
+    palette[i] = rgbFromCgram(start + i);
+  }
+}
+
+void TileRenderer::buildBlackWhitePalette() {
+  const unsigned nColors = colorsPerTile();
+
+  uint8_t delta = 255 / (nColors - 1);
+
+  uint8_t pixel = 0;
+  for(unsigned i = 0; i < nColors; i++) {
+    palette[i] = qRgb(pixel, pixel, pixel);
+    pixel += delta;
+  }
+}
+
+void TileRenderer::draw() {
+  if(!SNES::cartridge.loaded()) { invalidateImage(); return; }
+  if(bitDepth == BitDepth::NONE) { invalidateImage(); return; }
+
+  if(useCgramPalette) {
+    buildCgramPalette();
+  } else {
+    buildBlackWhitePalette();
+  }
+
+  if(width < 8) width = 8;
+  if(width > 64) width = 64;
+
+  if(bitDepth == BitDepth::MODE7) { drawMode7Tileset(); return; }
+
+  drawVramTileset();
+}
+
+void TileRenderer::drawVramTileset() {
+  const unsigned height = (nTiles() + width - 1) / width;
+
+  initImage(width * 8, height * 8);
+
+  QRgb* scanline = (QRgb*)image.scanLine(0);
+  const unsigned wordsPerScanline = image.bytesPerLine() / 4;
+  const unsigned bytesPerTile = bytesInbetweenTiles();
+
+  const uint8_t *tile = SNES::memory::vram.data();
+  const uint8_t *tileEnd = tile + SNES::memory::vram.size();
+
+  for(unsigned y = 0; y < height; y++) {
+    QRgb* imgBits = scanline;
+    scanline += wordsPerScanline * 8;
+
+    for(unsigned x = 0; x < width; x++) {
+      if(tile < tileEnd) {
+        draw8pxTile(imgBits, wordsPerScanline, tile, 0, 0, 0);
+
+        imgBits += 8;
+        tile += bytesPerTile;
+      }
+    }
+  }
+}
+
+void TileRenderer::drawMode7Tileset() {
+  const unsigned height = (256 + width - 1) / width;
+
+  initImage(width * 8, height * 8);
+
+  QRgb* scanline = (QRgb*)image.scanLine(0);
+  const unsigned wordsPerScanline = image.bytesPerLine() / 4;
+
+  const uint8_t *tile = SNES::memory::vram.data() + 1;
+  const uint8_t *tileEnd = tile + 256 * 128;
+
+  for(unsigned y = 0; y < height; y++) {
+    QRgb* imgBits = scanline;
+    scanline += wordsPerScanline * 8;
+
+    for(unsigned x = 0; x < width; x++) {
+      if(tile < tileEnd) {
+        drawMode7Tile(imgBits, wordsPerScanline, tile);
+
+        tile += 128;
+        imgBits += 8;
+      }
+    }
+  }
+}

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp
@@ -20,6 +20,7 @@ unsigned TileRenderer::addressMask() const {
     case BitDepth::BPP4: return 0xffe0;
     case BitDepth::BPP2: return 0xfff0;
     case BitDepth::MODE7: return 0;
+    case BitDepth::MODE7_EXTBG: return 0;
   }
   return 0;
 }
@@ -27,7 +28,7 @@ unsigned TileRenderer::addressMask() const {
 unsigned TileRenderer::nTiles() const {
   if(source != Source::VRAM) return int(255 / width + 1) * width;
 
-  if(bitDepth == BitDepth::MODE7) return 256;
+  if(isMode7()) return 256;
 
   unsigned a = address & addressMask();
   return (0x10000 - a) / bytesInbetweenTiles();
@@ -71,7 +72,7 @@ void TileRenderer::draw() {
   if(width < 8) width = 8;
   if(width > 64) width = 64;
 
-  if(bitDepth == BitDepth::MODE7) { drawMode7Tileset(); return; }
+  if(isMode7()) { drawMode7Tileset(); return; }
 
   if(source == Source::VRAM) { drawVramTileset(); return; }
   if(source == Source::CPU_BUS) { drawCpuBusTiles(); return; }

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
@@ -1,5 +1,5 @@
 struct TileRenderer : public BaseRenderer {
-  enum Source { VRAM, CPU_BUS };
+  enum Source { VRAM, CPU_BUS, CART_ROM, CART_RAM, SA1_BUS, SFX_BUS };
 
   Source source;
   unsigned address;
@@ -14,6 +14,7 @@ public:
 
   unsigned addressMask() const;
   unsigned nTiles() const;
+  unsigned maxAddress() const;
 
   void draw();
 
@@ -23,5 +24,5 @@ private:
 
   void drawVramTileset();
   void drawMode7Tileset();
-  void drawCpuBusTiles();
+  void drawMemorySourceTiles();
 };

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
@@ -2,7 +2,7 @@ struct TileRenderer : public BaseRenderer {
   enum Source { VRAM, CPU_BUS };
 
   Source source;
-  unsigned cpuAddress;
+  unsigned address;
 
   unsigned width;
 
@@ -12,6 +12,7 @@ struct TileRenderer : public BaseRenderer {
 public:
   TileRenderer();
 
+  unsigned addressMask() const;
   unsigned nTiles() const;
 
   void draw();

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
@@ -1,0 +1,20 @@
+struct TileRenderer : public BaseRenderer {
+  unsigned width;
+
+  unsigned paletteOffset;
+  bool useCgramPalette;
+
+public:
+  TileRenderer();
+
+  unsigned nTiles() const;
+
+  void draw();
+
+private:
+  void buildCgramPalette();
+  void buildBlackWhitePalette();
+
+  void drawVramTileset();
+  void drawMode7Tileset();
+};

--- a/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-renderer.hpp
@@ -1,4 +1,9 @@
 struct TileRenderer : public BaseRenderer {
+  enum Source { VRAM, CPU_BUS };
+
+  Source source;
+  unsigned cpuAddress;
+
   unsigned width;
 
   unsigned paletteOffset;
@@ -17,4 +22,5 @@ private:
 
   void drawVramTileset();
   void drawMode7Tileset();
+  void drawCpuBusTiles();
 };

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -94,6 +94,7 @@ TileViewer::TileViewer() {
   bitDepth->addItem("4bpp", QVariant(TileRenderer::BPP4));
   bitDepth->addItem("8bpp", QVariant(TileRenderer::BPP8));
   bitDepth->addItem("Mode 7", QVariant(TileRenderer::MODE7));
+  bitDepth->addItem("Mode 7 EXTBG", QVariant(TileRenderer::MODE7_EXTBG));
   sidebarLayout->addRow("Bit Depth:", bitDepth);
 
   widthSpinBox = new QSpinBox;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -14,6 +14,7 @@ TileViewer::TileViewer() {
   application.windowList.append(this);
 
   inUpdateFormCall = false;
+  inExportClickedCall = false;
 
   layout = new QHBoxLayout;
   layout->setSizeConstraint(QLayout::SetMinimumSize);
@@ -183,7 +184,7 @@ void TileViewer::show() {
 }
 
 void TileViewer::refresh() {
-  if(inUpdateFormCall) return;
+  if(inUpdateFormCall || inExportClickedCall) return;
 
   if(SNES::cartridge.loaded()) {
     cgramWidget->refresh();
@@ -207,6 +208,8 @@ void TileViewer::onZoomChanged(int index) {
 void TileViewer::onExportClicked() {
   if(renderer.image.isNull()) return;
 
+  inExportClickedCall = true;
+
   QFileDialog saveDialog(this, "Export Tiles");
   saveDialog.setAcceptMode(QFileDialog::AcceptSave);
   saveDialog.setNameFilter("PNG Image (*.png)");
@@ -222,6 +225,8 @@ void TileViewer::onExportClicked() {
       QMessageBox::critical(this, "ERROR", "Unable to export tiles\n\n" + writer.errorString());
     }
   }
+
+  inExportClickedCall = false;
 }
 
 void TileViewer::onUseCgramPressed() {

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -237,10 +237,10 @@ void TileViewer::onExportClicked() {
   saveDialog.setDefaultSuffix("png");
   saveDialog.exec();
 
-  QString filename = saveDialog.selectedFiles().first();
+  QStringList selectedFiles = saveDialog.selectedFiles();
 
-  if(saveDialog.result() == QDialog::Accepted && !filename.isEmpty()) {
-    QImageWriter writer(filename, "PNG");
+  if(saveDialog.result() == QDialog::Accepted && selectedFiles.size() == 1) {
+    QImageWriter writer(selectedFiles.first(), "PNG");
     bool s = writer.write(renderer.image);
     if(s == false) {
       QMessageBox::critical(this, "ERROR", "Unable to export tiles\n\n" + writer.errorString());

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -208,17 +208,16 @@ void TileViewer::show() {
 void TileViewer::refresh() {
   if(inUpdateFormCall || inExportClickedCall) return;
 
+  updateRendererSettings();
+
   if(SNES::cartridge.loaded()) {
     cgramWidget->refresh();
 
-    updateRendererSettings();
-
     renderer.draw();
     imageGridWidget->setImage(renderer.image);
-
-    updateForm();
   }
 
+  updateForm();
   updateTileInfo();
 }
 

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -158,13 +158,13 @@ TileViewer::TileViewer() {
   connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
   connect(showGrid,      SIGNAL(clicked(bool)), imageGridWidget, SLOT(setShowGrid(bool)));
 
-  connect(source,        SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
-  connect(cpuAddress,    SIGNAL(textChanged(const QString&)), this, SLOT(refresh()));
-  connect(bitDepth,      SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
-  connect(widthSpinBox,  SIGNAL(valueChanged(int)),           this, SLOT(refresh()));
+  connect(source,        SIGNAL(activated(int)),             this, SLOT(refresh()));
+  connect(cpuAddress,    SIGNAL(textEdited(const QString&)), this, SLOT(refresh()));
+  connect(bitDepth,      SIGNAL(activated(int)),             this, SLOT(refresh()));
+  connect(widthSpinBox,  SIGNAL(valueChanged(int)),          this, SLOT(refresh()));
 
-  connect(overrideBackgroundColor, SIGNAL(clicked(bool)), this, SLOT(refresh()));
-  connect(customBgColorCombo,      SIGNAL(currentIndexChanged(int)), this, SLOT(refresh()));
+  connect(overrideBackgroundColor, SIGNAL(clicked(bool)),    this, SLOT(refresh()));
+  connect(customBgColorCombo,      SIGNAL(activated(int)),   this, SLOT(refresh()));
 
   connect(useCgram,    SIGNAL(clicked()), this, SLOT(onUseCgramPressed()));
   connect(cgramWidget, SIGNAL(selectedChanged()), this, SLOT(refresh()));

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -1,0 +1,294 @@
+#include "tile-viewer.moc"
+
+TileViewer *tileViewer;
+
+const char* TileViewer::VramBaseText[6] = {
+  "BG1:", "BG2:", "BG3:", "BG4:",
+  "OAM1:", "OAM2:"
+};
+
+TileViewer::TileViewer() {
+  setObjectName("tile-viewer");
+  setWindowTitle("Tile Viewer");
+  setGeometryString(&config().geometry.tileViewer);
+  application.windowList.append(this);
+
+  inUpdateFormCall = false;
+
+  layout = new QHBoxLayout;
+  layout->setSizeConstraint(QLayout::SetMinimumSize);
+  layout->setAlignment(Qt::AlignLeft);
+  layout->setMargin(Style::WindowMargin);
+  layout->setSpacing(Style::WidgetSpacing);
+  setLayout(layout);
+
+  sidebarLayout = new QFormLayout;
+  sidebarLayout->setSizeConstraint(QLayout::SetMinimumSize);
+  sidebarLayout->setRowWrapPolicy(QFormLayout::DontWrapRows);
+  sidebarLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+  sidebarLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
+  sidebarLayout->setLabelAlignment(Qt::AlignLeft);
+  layout->addLayout(sidebarLayout);
+
+
+  zoomCombo = new QComboBox;
+  zoomCombo->addItem("1x", QVariant(1));
+  zoomCombo->addItem("2x", QVariant(2));
+  zoomCombo->addItem("3x", QVariant(3));
+  zoomCombo->addItem("4x", QVariant(4));
+  zoomCombo->addItem("5x", QVariant(5));
+  zoomCombo->addItem("6x", QVariant(6));
+  zoomCombo->addItem("7x", QVariant(7));
+  zoomCombo->addItem("8x", QVariant(8));
+  zoomCombo->addItem("9x", QVariant(9));
+
+  showGrid = new QCheckBox("Show Grid");
+  sidebarLayout->addRow(zoomCombo, showGrid);
+
+  autoUpdateBox = new QCheckBox("Auto update");
+  sidebarLayout->addRow("", autoUpdateBox);
+
+
+  buttonLayout = new QHBoxLayout;
+
+  exportButton = new QPushButton("Export");
+  buttonLayout->addWidget(exportButton);
+
+  refreshButton = new QPushButton("Refresh");
+  buttonLayout->addWidget(refreshButton);
+
+  sidebarLayout->addRow(buttonLayout);
+
+
+  sidebarLayout->addRow(new QWidget);
+
+  bitDepth = new QComboBox;
+  bitDepth->addItem("2bpp", QVariant(TileRenderer::BPP2));
+  bitDepth->addItem("4bpp", QVariant(TileRenderer::BPP4));
+  bitDepth->addItem("8bpp", QVariant(TileRenderer::BPP8));
+  bitDepth->addItem("Mode 7", QVariant(TileRenderer::MODE7));
+  sidebarLayout->addRow("Bit Depth:", bitDepth);
+
+  widthSpinBox = new QSpinBox;
+  widthSpinBox->setMinimum(8);
+  widthSpinBox->setMaximum(64);
+  widthSpinBox->setValue(16);
+  sidebarLayout->addRow("Width:", widthSpinBox);
+
+
+  sidebarLayout->addRow(new QWidget);
+
+  overrideBackgroundColor = new QCheckBox("Override Background Color");
+  sidebarLayout->addRow(overrideBackgroundColor);
+
+  customBgColorCombo = new QComboBox;
+  customBgColorCombo->addItem("Transparent", QVariant(qRgba(0, 0, 0, 0)));
+  customBgColorCombo->addItem("Magenta",     QVariant(qRgb(255, 0, 255)));
+  customBgColorCombo->addItem("Cyan",        QVariant(qRgb(0, 255, 255)));
+  customBgColorCombo->addItem("White",       QVariant(qRgb(255, 255, 255)));
+  customBgColorCombo->addItem("Black",       QVariant(qRgb(0, 0, 0)));
+  sidebarLayout->addRow("BG Color:", customBgColorCombo);
+
+
+  sidebarLayout->addRow(new QWidget);
+
+  useCgram = new QCheckBox("Use CGRAM");
+  sidebarLayout->addRow(useCgram);
+
+  cgramWidget = new CgramWidget;
+  cgramWidget->setScale(12);
+  sidebarLayout->addRow(cgramWidget);
+
+
+  sidebarLayout->addRow(new QWidget);
+
+  sidebarLayout->addRow(new QLabel("Base Tile Addresses:"));
+
+  vramBaseLayout = new QGridLayout;
+  vramBaseLayout->setColumnStretch(0, 1);
+  sidebarLayout->addRow(vramBaseLayout);
+
+  vramBaseButtonGroup = new QButtonGroup(this);
+
+  for(unsigned i = 0; i < N_VRAM_BASE_ITEMS; i++) {
+    QLabel* label = new QLabel(VramBaseText[i]);
+    vramBaseLayout->addWidget(label, i, 1);
+
+    vramBaseAddress[i] = new QLineEdit;
+    vramBaseAddress[i]->setReadOnly(true);
+    vramBaseAddress[i]->setFixedWidth(9 * vramBaseAddress[i]->fontMetrics().width('0'));
+    vramBaseLayout->addWidget(vramBaseAddress[i], i, 2);
+
+    vramBaseButton[i] = new QToolButton;
+    vramBaseButton[i]->setText("goto");
+    vramBaseLayout->addWidget(vramBaseButton[i], i, 3);
+
+    vramBaseButtonGroup->addButton(vramBaseButton[i], i);
+  }
+
+
+  sidebarLayout->addRow(new QWidget);
+
+  tileInfo = new QLabel;
+  sidebarLayout->addRow(tileInfo);
+
+
+  imageGridWidget = new ImageGridWidget();
+  imageGridWidget->setMinimumSize(256, 256);
+  imageGridWidget->setGridSize(8);
+  imageGridWidget->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  layout->addWidget(imageGridWidget, 10);
+
+
+  zoomCombo->setCurrentIndex(3 - 1);
+  onZoomChanged(3 - 1);
+  updateForm();
+
+  connect(exportButton,  SIGNAL(clicked(bool)), this, SLOT(onExportClicked()));
+  connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
+  connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
+  connect(showGrid,      SIGNAL(clicked(bool)), imageGridWidget, SLOT(setShowGrid(bool)));
+
+  connect(bitDepth,      SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
+  connect(widthSpinBox,  SIGNAL(valueChanged(int)),           this, SLOT(refresh()));
+
+  connect(overrideBackgroundColor, SIGNAL(clicked(bool)), this, SLOT(refresh()));
+  connect(customBgColorCombo,      SIGNAL(currentIndexChanged(int)), this, SLOT(refresh()));
+
+  connect(useCgram,    SIGNAL(clicked()), this, SLOT(onUseCgramPressed()));
+  connect(cgramWidget, SIGNAL(selectedChanged()), this, SLOT(refresh()));
+
+  connect(imageGridWidget, SIGNAL(selectedChanged()), this, SLOT(updateTileInfo()));
+
+  connect(vramBaseButtonGroup, SIGNAL(buttonClicked(int)), this, SLOT(onVramBaseButtonClicked(int)));
+}
+
+void TileViewer::autoUpdate() {
+  if(autoUpdateBox->isChecked()) refresh();
+}
+
+void TileViewer::show() {
+  Window::show();
+  refresh();
+}
+
+void TileViewer::refresh() {
+  if(inUpdateFormCall) return;
+
+  if(SNES::cartridge.loaded()) {
+    cgramWidget->refresh();
+
+    updateRendererSettings();
+
+    renderer.draw();
+    imageGridWidget->setImage(renderer.image);
+
+    updateForm();
+  }
+
+  updateTileInfo();
+}
+
+void TileViewer::onZoomChanged(int index) {
+  unsigned z = zoomCombo->itemData(index).toUInt();
+  imageGridWidget->setZoom(z);
+}
+
+void TileViewer::onExportClicked() {
+  if(renderer.image.isNull()) return;
+
+  QFileDialog saveDialog(this, "Export Tiles");
+  saveDialog.setAcceptMode(QFileDialog::AcceptSave);
+  saveDialog.setNameFilter("PNG Image (*.png)");
+  saveDialog.setDefaultSuffix("png");
+  saveDialog.exec();
+
+  QString filename = saveDialog.selectedFiles().first();
+
+  if(saveDialog.result() == QDialog::Accepted && !filename.isEmpty()) {
+    QImageWriter writer(filename, "PNG");
+    bool s = writer.write(renderer.image);
+    if(s == false) {
+      QMessageBox::critical(this, "ERROR", "Unable to export tiles\n\n" + writer.errorString());
+    }
+  }
+}
+
+void TileViewer::onUseCgramPressed() {
+  if(useCgram->isChecked()) {
+    if(!cgramWidget->hasSelected()) cgramWidget->setSelected(0);
+  } else {
+    cgramWidget->selectNone();
+  }
+}
+
+void TileViewer::onVramBaseButtonClicked(int index) {
+  unsigned addr = hex(vramBaseAddress[index]->text().toUtf8().data());
+
+  unsigned tileId = addr / renderer.bytesInbetweenTiles();
+
+  QPoint cell(tileId % renderer.width, tileId / renderer.width);
+  imageGridWidget->setSelected(cell);
+  imageGridWidget->scrollToCell(cell);
+}
+
+void TileViewer::updateRendererSettings() {
+  typedef TileRenderer::BitDepth Depth;
+
+  int bd = bitDepth->currentIndex();
+  renderer.bitDepth = bd >= 0 ? Depth(bitDepth->itemData(bd).toInt()) : Depth::NONE;
+
+  int ci = customBgColorCombo->currentIndex();
+  renderer.overrideBackgroundColor = overrideBackgroundColor->isChecked();
+  renderer.customBackgroundColor = customBgColorCombo->itemData(ci).toUInt();
+
+  renderer.width = widthSpinBox->value();
+
+  if(cgramWidget->hasSelected()) {
+    renderer.paletteOffset = cgramWidget->selectedColor();
+    useCgram->setChecked(true);
+  }
+
+  renderer.useCgramPalette = useCgram->isChecked();
+}
+
+void TileViewer::updateForm() {
+  inUpdateFormCall = true;
+
+  exportButton->setEnabled(!renderer.image.isNull());
+
+  bitDepth->setCurrentIndex(bitDepth->findData(renderer.bitDepth));
+
+  cgramWidget->setPaletteSize(renderer.colorsPerTile());
+
+  customBgColorCombo->setEnabled(overrideBackgroundColor->isChecked());
+
+  for(unsigned i = 0; i < N_VRAM_BASE_ITEMS; i++) {
+    unsigned a = 0;
+    if(i < 4) a = SNES::ppu.bg_tile_addr(i);
+    if(i >= 4 && i < 6) a = SNES::ppu.oam_tile_addr(i - 4);
+
+    vramBaseAddress[i]->setText(string("0x", hex<4>(a)));
+  }
+
+  inUpdateFormCall = false;
+}
+
+void TileViewer::updateTileInfo() {
+  if(!SNES::cartridge.loaded()) { tileInfo->clear(); return; }
+  if(!imageGridWidget->selectionValid()) { tileInfo->clear(); return; }
+
+  unsigned tileId = imageGridWidget->selected().y() * renderer.width + imageGridWidget->selected().x();
+
+  string text;
+  if(tileId < renderer.nTiles()) {
+    unsigned tileAddr = tileId * renderer.bytesInbetweenTiles();
+
+    text = string("Selected Tile Address: ", hex<4>(tileAddr));
+
+  } else {
+    imageGridWidget->selectNone();
+  }
+
+  tileInfo->setText(text);
+}

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -66,6 +66,10 @@ TileViewer::TileViewer() {
   source = new QComboBox;
   source->addItem("VRAM", QVariant(TileRenderer::VRAM));
   source->addItem("S-CPU Bus", QVariant(TileRenderer::CPU_BUS));
+  source->addItem("Cartridge ROM", QVariant(TileRenderer::CART_ROM));
+  source->addItem("Cartridge RAM", QVariant(TileRenderer::CART_RAM));
+  source->addItem("SA1 Bus", QVariant(TileRenderer::SA1_BUS));
+  source->addItem("SFX Bus", QVariant(TileRenderer::SFX_BUS));
   sidebarLayout->addRow("Source:", source);
 
 
@@ -297,11 +301,11 @@ void TileViewer::stepAdddressField(bool forward) {
   unsigned step = renderer.bytesInbetweenTiles();
   if(renderer.source != TileRenderer::VRAM) step *= renderer.nTiles();
 
-  unsigned max = renderer.source == TileRenderer::VRAM ? 0x10000 : 0x1000000;
-
   if(forward) {
+    unsigned max = renderer.maxAddress();
     unsigned a = renderer.address + step;
     if(a >= max) a = max - step;
+    if(step > max) a = 0;
     renderer.address = a;
   } else {
     if(renderer.address >= step) {

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -43,7 +43,7 @@ private:
   QCheckBox *showGrid;
 
   QComboBox *source;
-  QLineEdit *cpuAddress;
+  QLineEdit *address;
 
   QComboBox *bitDepth;
   QSpinBox  *widthSpinBox;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -20,9 +20,14 @@ public slots:
   void onUseCgramPressed();
   void onVramBaseButtonClicked(int);
 
+  void onPrevAddressButtonClicked();
+  void onNextAddressButtonClicked();
+
 private:
   void updateRendererSettings();
   void updateForm();
+
+  void stepAdddressField(bool forward);
 
   unsigned getVramBaseAddress(unsigned index);
 
@@ -32,6 +37,7 @@ private:
   QHBoxLayout *layout;
   QFormLayout *sidebarLayout;
   QHBoxLayout *buttonLayout;
+  QHBoxLayout *addressLayout;
   QGridLayout *vramBaseLayout;
 
   QCheckBox *autoUpdateBox;
@@ -44,6 +50,8 @@ private:
 
   QComboBox *source;
   QLineEdit *address;
+  QToolButton *prevAddressButton;
+  QToolButton *nextAddressButton;
 
   QComboBox *bitDepth;
   QSpinBox  *widthSpinBox;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -24,6 +24,8 @@ private:
   void updateRendererSettings();
   void updateForm();
 
+  unsigned getVramBaseAddress(unsigned index);
+
 private:
   TileRenderer renderer;
 

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -1,32 +1,36 @@
 
-class TilemapViewer : public Window {
+class TileViewer : public Window {
   Q_OBJECT
 
+  const static unsigned N_VRAM_BASE_ITEMS = 6;
+  const static char* VramBaseText[N_VRAM_BASE_ITEMS];
+
 public:
-  TilemapViewer();
+  TileViewer();
   void autoUpdate();
 
 public slots:
   void show();
   void refresh();
+  void updateTileInfo();
 
   void onZoomChanged(int);
   void onExportClicked();
 
+  void onUseCgramPressed();
+  void onVramBaseButtonClicked(int);
+
 private:
   void updateRendererSettings();
   void updateForm();
-  void updateTileInfo();
-  void updateTileInfoNormal();
-  void updateTileInfoMode7();
 
 private:
-  TilemapRenderer renderer;
+  TileRenderer renderer;
 
   QHBoxLayout *layout;
   QFormLayout *sidebarLayout;
   QHBoxLayout *buttonLayout;
-  QHBoxLayout *bgLayout;
+  QGridLayout *vramBaseLayout;
 
   QCheckBox *autoUpdateBox;
 
@@ -36,25 +40,24 @@ private:
   QComboBox *zoomCombo;
   QCheckBox *showGrid;
 
-  QCheckBox *customScreenMode;
-  QCheckBox *customTilemap;
-
-  QSpinBox  *screenMode;
-  QToolButton *bgButtons[4];
   QComboBox *bitDepth;
-  QComboBox *screenSize;
-  QComboBox *tileSize;
-  QLineEdit *tileAddr;
-  QLineEdit *screenAddr;
+  QSpinBox  *widthSpinBox;
 
   QCheckBox *overrideBackgroundColor;
   QComboBox *customBgColorCombo;
 
+  QCheckBox *useCgram;
+  CgramWidget *cgramWidget;
+
+  QButtonGroup *vramBaseButtonGroup;
+  QLineEdit *vramBaseAddress[N_VRAM_BASE_ITEMS];
+  QToolButton *vramBaseButton[N_VRAM_BASE_ITEMS];
+
   QLabel *tileInfo;
 
-  ImageGridWidget *imageGridWidget;
+  ImageGridWidget* imageGridWidget;
 
   bool inUpdateFormCall;
 };
 
-extern TilemapViewer *tilemapViewer;
+extern TileViewer *tileViewer;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -61,6 +61,7 @@ private:
   ImageGridWidget* imageGridWidget;
 
   bool inUpdateFormCall;
+  bool inExportClickedCall;
 };
 
 extern TileViewer *tileViewer;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.moc.hpp
@@ -40,6 +40,9 @@ private:
   QComboBox *zoomCombo;
   QCheckBox *showGrid;
 
+  QComboBox *source;
+  QLineEdit *cpuAddress;
+
   QComboBox *bitDepth;
   QSpinBox  *widthSpinBox;
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
@@ -18,13 +18,13 @@ void TilemapRenderer::updateBitDepth() {
 }
 
 unsigned TilemapRenderer::nLayersInMode() const {
-  const static unsigned layers[8] = { 4, 3, 2, 2, 2, 2, 1, 1 };
+  const static unsigned layers[8] = { 4, 3, 2, 2, 2, 2, 1, 2 };
 
   return layers[screenMode & 7];
 }
 
 unsigned TilemapRenderer::tileSizePx() const {
-  if(bitDepth != BitDepth::MODE7) {
+  if(!isMode7()) {
     return tileSize ? 16 : 8;
   } else {
     return 8;
@@ -33,6 +33,9 @@ unsigned TilemapRenderer::tileSizePx() const {
 
 void TilemapRenderer::loadScreenMode() {
   screenMode = SNES::ppu.bg_mode() & 7;
+  if(screenMode == 7) {
+      layer = SNES::ppu.mode7_extbg();
+  }
 }
 
 void TilemapRenderer::loadTilemapSettings() {
@@ -61,7 +64,7 @@ void TilemapRenderer::loadTilemapSettings() {
 void TilemapRenderer::drawTilemap() {
   buildPalette();
 
-  if(bitDepth == BitDepth::MODE7) { drawMode7Tilemap(); return; }
+  if(isMode7()) { drawMode7Tilemap(); return; }
   if(bitDepth == BitDepth::NONE) { invalidateImage(); return; }
 
   unsigned mapSize = tileSize ? 512 : 256;

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
@@ -106,7 +106,7 @@ void TilemapRenderer::drawMap(QImage& image, unsigned mapAddr, unsigned startX, 
   const uint8_t *map = SNES::memory::vram.data() + mapAddr;
 
   for(unsigned ty = 0; ty < 32; ty++) {
-    uint32_t* imgBits = (uint32_t*)image.scanLine(startY + ty * ts) + startX;
+    QRgb* imgBits = (QRgb*)image.scanLine(startY + ty * ts) + startX;
 
     for(unsigned tx = 0; tx < 32; tx++) {
       drawMapTile(imgBits, wordsPerScanline, map);
@@ -116,7 +116,7 @@ void TilemapRenderer::drawMap(QImage& image, unsigned mapAddr, unsigned startX, 
   }
 }
 
-void TilemapRenderer::drawMapTile(uint32_t* imgBits, const unsigned wordsPerScanline, const uint8_t* map) {
+void TilemapRenderer::drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* map) {
   unsigned ts = tileSize ? 16 : 8;
   uint16_t tile = map[0] | (map[1] << 8);
 
@@ -144,7 +144,7 @@ void TilemapRenderer::drawMapTile(uint32_t* imgBits, const unsigned wordsPerScan
     unsigned c4 = c2 + 0x010;
     if (vFlip) { swap(c1, c3); swap(c2, c4); }
 
-    uint32_t* row2Bits = imgBits + wordsPerScanline * 8;
+    QRgb* row2Bits = imgBits + wordsPerScanline * 8;
     draw8pxTile(imgBits  + 0, wordsPerScanline, c1, pal, hFlip, vFlip);
     draw8pxTile(imgBits  + 8, wordsPerScanline, c2, pal, hFlip, vFlip);
     draw8pxTile(row2Bits + 0, wordsPerScanline, c3, pal, hFlip, vFlip);
@@ -152,7 +152,7 @@ void TilemapRenderer::drawMapTile(uint32_t* imgBits, const unsigned wordsPerScan
   }
 }
 
-void TilemapRenderer::draw8pxTile(uint32_t* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip) {
+void TilemapRenderer::draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip) {
   uint8_t data[8];
 
   unsigned addr = 0;
@@ -218,13 +218,13 @@ void TilemapRenderer::draw8pxTile(uint32_t* imgBits, const unsigned wordsPerScan
 QImage TilemapRenderer::drawMode7Tilemap() {
   QImage image(1024, 1024, QImage::Format_RGB32);
 
-  uint32_t* scanline = (uint32_t*)image.scanLine(0);
+  QRgb* scanline = (QRgb*)image.scanLine(0);
   unsigned wordsPerScanline = image.bytesPerLine() / 4;
 
   const uint8_t *map = SNES::memory::vram.data();
 
   for(unsigned ty = 0; ty < 128; ty++) {
-    uint32_t* imgBits = scanline;
+    QRgb* imgBits = scanline;
     scanline += wordsPerScanline * 8;
 
     for(unsigned tx = 0; tx < 128; tx++) {
@@ -239,7 +239,7 @@ QImage TilemapRenderer::drawMode7Tilemap() {
   return image;
 }
 
-void TilemapRenderer::drawMode7Tile(uint32_t* imgBits, const unsigned wordsPerScanline, unsigned c) {
+void TilemapRenderer::drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c) {
   const uint8_t *tile = SNES::memory::vram.data() + c * 128 + 1;
 
   for(unsigned py = 0; py < 8; py++) {

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
@@ -12,20 +12,9 @@ TilemapRenderer::TilemapRenderer()
 }
 
 void TilemapRenderer::updateBitDepth() {
-  static const BitDepth map[8][4] = {
-    { BPP2, BPP2, BPP2, BPP2},
-    { BPP4, BPP4, BPP2, NONE},
-    { BPP4, BPP4, NONE, NONE},
-    { BPP8, BPP4, NONE, NONE},
-    { BPP8, BPP2, NONE, NONE},
-    { BPP4, BPP2, NONE, NONE},
-    { BPP4, NONE, NONE, NONE},
-    { MODE7, MODE7, MODE7, MODE7}
-  };
-
   layer = layer & 3;
   screenMode = screenMode & 7;
-  bitDepth = map[screenMode][layer];
+  bitDepth = bitDepthForLayer(screenMode, layer);
 }
 
 unsigned TilemapRenderer::nLayersInMode() const {

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -4,6 +4,8 @@ struct TilemapRenderer {
   QRgb palette[256];
   QImage image;
 
+  QRgb customBackgroundColor;
+
   unsigned screenMode;
   unsigned layer;
 
@@ -14,6 +16,8 @@ struct TilemapRenderer {
   bool screenSizeX;
   bool screenSizeY;
   bool tileSize;
+
+  bool overrideBackgroundColor;
 
 public:
   TilemapRenderer();
@@ -30,7 +34,7 @@ public:
   void drawTilemap();
 
 private:
-  void setImageSize(unsigned width, unsigned height);
+  void initImage(unsigned width, unsigned height);
   void invalidateImage();
 
   void drawMap(unsigned mapAddr, unsigned startX, unsigned startY);

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -1,7 +1,7 @@
 struct TilemapRenderer {
   enum BitDepth { BPP8, BPP4, BPP2, MODE7, NONE };
 
-  uint32_t palette[256];
+  QRgb palette[256];
 
   unsigned screenMode;
   unsigned layer;
@@ -30,9 +30,9 @@ public:
 
 private:
   void drawMap(QImage& image, unsigned mapAddr, unsigned startX, unsigned startY);
-  void drawMapTile(uint32_t* imgBits, const unsigned wordsPerScanline, const uint8_t* map);
-  void draw8pxTile(uint32_t* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip);
+  void drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* map);
+  void draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip);
 
   QImage drawMode7Tilemap();
-  void drawMode7Tile(uint32_t* imgBits, const unsigned wordsPerScanline, unsigned c);
+  void drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c);
 };

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -1,23 +1,13 @@
-struct TilemapRenderer {
-  enum BitDepth { BPP8, BPP4, BPP2, MODE7, NONE };
-
-  QRgb palette[256];
-  QImage image;
-
-  QRgb customBackgroundColor;
-
+struct TilemapRenderer : public BaseRenderer {
   unsigned screenMode;
   unsigned layer;
 
-  BitDepth bitDepth;
   unsigned tileAddr;
   unsigned screenAddr;
 
   bool screenSizeX;
   bool screenSizeY;
   bool tileSize;
-
-  bool overrideBackgroundColor;
 
 public:
   TilemapRenderer();
@@ -29,18 +19,12 @@ public:
   unsigned nLayersInMode() const;
   unsigned tileSizePx() const;
 
-  void buildPalette();
-
   void drawTilemap();
 
 private:
-  void initImage(unsigned width, unsigned height);
-  void invalidateImage();
-
   void drawMap(unsigned mapAddr, unsigned startX, unsigned startY);
   void drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* map);
-  void draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip);
+  void drawMap8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, unsigned palOffset, bool hFlip, bool vFlip);
 
   void drawMode7Tilemap();
-  void drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c);
 };

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -2,6 +2,7 @@ struct TilemapRenderer {
   enum BitDepth { BPP8, BPP4, BPP2, MODE7, NONE };
 
   QRgb palette[256];
+  QImage image;
 
   unsigned screenMode;
   unsigned layer;
@@ -26,13 +27,16 @@ public:
 
   void buildPalette();
 
-  QImage drawTilemap();
+  void drawTilemap();
 
 private:
-  void drawMap(QImage& image, unsigned mapAddr, unsigned startX, unsigned startY);
+  void setImageSize(unsigned width, unsigned height);
+  void invalidateImage();
+
+  void drawMap(unsigned mapAddr, unsigned startX, unsigned startY);
   void drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* map);
   void draw8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, uint8_t pal, bool hFlip, bool vFlip);
 
-  QImage drawMode7Tilemap();
+  void drawMode7Tilemap();
   void drawMode7Tile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c);
 };

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -175,16 +175,15 @@ void TilemapViewer::show() {
 void TilemapViewer::refresh() {
   if(inUpdateFormCall || inExportClickedCall) return;
 
-  if(SNES::cartridge.loaded()) {
-    updateRendererSettings();
+  updateRendererSettings();
 
+  if(SNES::cartridge.loaded()) {
     renderer.drawTilemap();
     imageGridWidget->setImage(renderer.image);
     imageGridWidget->setGridSize(renderer.tileSizePx());
-
-    updateForm();
   }
 
+  updateForm();
   updateTileInfo();
 }
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -89,6 +89,7 @@ TilemapViewer::TilemapViewer() {
   bitDepth->addItem("4bpp", QVariant(TilemapRenderer::BPP4));
   bitDepth->addItem("8bpp", QVariant(TilemapRenderer::BPP8));
   bitDepth->addItem("Mode 7", QVariant(TilemapRenderer::MODE7));
+  bitDepth->addItem("Mode 7 EXTBG", QVariant(TileRenderer::MODE7_EXTBG));
   sidebarLayout->addRow("Bit Depth:", bitDepth);
 
   screenSize = new QComboBox;
@@ -263,14 +264,14 @@ void TilemapViewer::updateForm() {
   }
 
   unsigned nLayers = renderer.nLayersInMode();
-  if(renderer.screenMode == 7) nLayers = 0;
+  if(!csm && renderer.screenMode == 7) nLayers = 0;
   for(unsigned i = 0; i < 4; i++) {
     bgButtons[i]->setChecked(i == renderer.layer);
     bgButtons[i]->setEnabled(i < nLayers);
   }
 
   bool ct = customTilemap->isChecked();
-  bool mode7 = renderer.bitDepth == TilemapRenderer::MODE7;
+  bool mode7 = renderer.isMode7();
 
   bitDepth->setEnabled(ct);
   screenAddr->setEnabled(ct & !mode7);
@@ -297,7 +298,7 @@ void TilemapViewer::updateForm() {
 
 void TilemapViewer::updateTileInfo() {
   if(SNES::cartridge.loaded() && imageGridWidget->selectionValid()) {
-    if(renderer.bitDepth != TilemapRenderer::MODE7) {
+    if(!renderer.isMode7()) {
       updateTileInfoNormal();
     } else {
       updateTileInfoMode7();

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -9,6 +9,7 @@ TilemapViewer::TilemapViewer() {
   application.windowList.append(this);
 
   inUpdateFormCall = false;
+  inExportClickedCall = false;
 
   layout = new QHBoxLayout;
   layout->setSizeConstraint(QLayout::SetMinimumSize);
@@ -171,7 +172,7 @@ void TilemapViewer::show() {
 }
 
 void TilemapViewer::refresh() {
-  if(inUpdateFormCall) return;
+  if(inUpdateFormCall || inExportClickedCall) return;
 
   if(SNES::cartridge.loaded()) {
     updateRendererSettings();
@@ -194,6 +195,8 @@ void TilemapViewer::onZoomChanged(int index) {
 void TilemapViewer::onExportClicked() {
   if(renderer.image.isNull()) return;
 
+  inExportClickedCall = true;
+
   QFileDialog saveDialog(this, "Export Tilemap");
   saveDialog.setAcceptMode(QFileDialog::AcceptSave);
   saveDialog.setNameFilter("PNG Image (*.png)");
@@ -209,6 +212,8 @@ void TilemapViewer::onExportClicked() {
       QMessageBox::critical(this, "ERROR", "Unable to export tilemap\n\n" + writer.errorString());
     }
   }
+
+  inExportClickedCall = false;
 }
 
 void TilemapViewer::updateRendererSettings() {

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -149,15 +149,15 @@ TilemapViewer::TilemapViewer() {
   for(int i = 0; i < 4; i++) {
     connect(bgButtons[i],SIGNAL(clicked(bool)),               this, SLOT(refresh()));
   }
-  connect(screenMode,    SIGNAL(valueChanged(int)),           this, SLOT(refresh()));
-  connect(bitDepth,      SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
-  connect(screenSize,    SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
-  connect(tileSize,      SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
-  connect(tileAddr,      SIGNAL(textChanged(const QString&)), this, SLOT(refresh()));
-  connect(screenAddr,    SIGNAL(textChanged(const QString&)), this, SLOT(refresh()));
+  connect(screenMode,    SIGNAL(valueChanged(int)),          this, SLOT(refresh()));
+  connect(bitDepth,      SIGNAL(activated(int)),             this, SLOT(refresh()));
+  connect(screenSize,    SIGNAL(activated(int)),             this, SLOT(refresh()));
+  connect(tileSize,      SIGNAL(activated(int)),             this, SLOT(refresh()));
+  connect(tileAddr,      SIGNAL(textEdited(const QString&)), this, SLOT(refresh()));
+  connect(screenAddr,    SIGNAL(textEdited(const QString&)), this, SLOT(refresh()));
 
-  connect(overrideBackgroundColor, SIGNAL(clicked(bool)), this, SLOT(refresh()));
-  connect(customBgColorCombo,    SIGNAL(currentIndexChanged(int)), this, SLOT(refresh()));
+  connect(overrideBackgroundColor, SIGNAL(clicked(bool)),    this, SLOT(refresh()));
+  connect(customBgColorCombo,      SIGNAL(activated(int)),   this, SLOT(refresh()));
 
   connect(imageGridWidget, SIGNAL(selectedChanged()),         this, SLOT(refresh()));
 }

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -203,10 +203,10 @@ void TilemapViewer::onExportClicked() {
   saveDialog.setDefaultSuffix("png");
   saveDialog.exec();
 
-  QString filename = saveDialog.selectedFiles().first();
+  QStringList selectedFiles = saveDialog.selectedFiles();
 
-  if(saveDialog.result() == QDialog::Accepted && !filename.isEmpty()) {
-    QImageWriter writer(filename, "PNG");
+  if(saveDialog.result() == QDialog::Accepted && selectedFiles.size() == 1) {
+    QImageWriter writer(selectedFiles.first(), "PNG");
     bool s = writer.write(renderer.image);
     if(s == false) {
       QMessageBox::critical(this, "ERROR", "Unable to export tilemap\n\n" + writer.errorString());

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -152,8 +152,8 @@ void TilemapViewer::refresh() {
 
     renderer.buildPalette();
 
-    QImage image = renderer.drawTilemap();
-    imageGridWidget->setImage(image);
+    renderer.drawTilemap();
+    imageGridWidget->setImage(renderer.image);
     imageGridWidget->setGridSize(renderer.tileSizePx());
   }
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -111,6 +111,20 @@ TilemapViewer::TilemapViewer() {
   sidebarLayout->addRow(new QWidget);
 
 
+  overrideBackgroundColor = new QCheckBox("Override Background Color");
+  sidebarLayout->addRow(overrideBackgroundColor);
+
+  customBgColorCombo = new QComboBox;
+  customBgColorCombo->addItem("Transparent", QVariant(qRgba(0, 0, 0, 0)));
+  customBgColorCombo->addItem("Magenta",     QVariant(qRgb(255, 0, 255)));
+  customBgColorCombo->addItem("Cyan",        QVariant(qRgb(0, 255, 255)));
+  customBgColorCombo->addItem("White",       QVariant(qRgb(255, 255, 255)));
+  customBgColorCombo->addItem("Black",       QVariant(qRgb(0, 0, 0)));
+  sidebarLayout->addRow("BG Color:", customBgColorCombo);
+
+
+  sidebarLayout->addRow(new QWidget);
+
   tileInfo = new QLabel;
   sidebarLayout->addRow(tileInfo);
 
@@ -140,6 +154,9 @@ TilemapViewer::TilemapViewer() {
   connect(tileSize,      SIGNAL(currentIndexChanged(int)),    this, SLOT(refresh()));
   connect(tileAddr,      SIGNAL(textChanged(const QString&)), this, SLOT(refresh()));
   connect(screenAddr,    SIGNAL(textChanged(const QString&)), this, SLOT(refresh()));
+
+  connect(overrideBackgroundColor, SIGNAL(clicked(bool)), this, SLOT(refresh()));
+  connect(customBgColorCombo,    SIGNAL(currentIndexChanged(int)), this, SLOT(refresh()));
 
   connect(imageGridWidget, SIGNAL(selectedChanged()),         this, SLOT(refresh()));
 }
@@ -224,6 +241,10 @@ void TilemapViewer::updateRendererSettings() {
   } else {
     renderer.loadTilemapSettings();
   }
+
+  int i = customBgColorCombo->currentIndex();
+  renderer.overrideBackgroundColor = overrideBackgroundColor->isChecked();
+  renderer.customBackgroundColor = customBgColorCombo->itemData(i).toUInt();
 }
 
 void TilemapViewer::updateForm() {
@@ -265,6 +286,8 @@ void TilemapViewer::updateForm() {
     screenSize->setCurrentIndex(ss);
     tileSize->setCurrentIndex(renderer.tileSize);
   }
+
+  customBgColorCombo->setEnabled(overrideBackgroundColor->isChecked());
 
   inUpdateFormCall = false;
 }

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -176,8 +176,6 @@ void TilemapViewer::refresh() {
   if(SNES::cartridge.loaded()) {
     updateRendererSettings();
 
-    renderer.buildPalette();
-
     renderer.drawTilemap();
     imageGridWidget->setImage(renderer.image);
     imageGridWidget->setGridSize(renderer.tileSizePx());

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -11,6 +11,7 @@ public slots:
   void refresh();
 
   void onZoomChanged(int);
+  void onExportClicked();
 
 private:
   void updateRendererSettings();
@@ -24,9 +25,12 @@ private:
 
   QHBoxLayout *layout;
   QFormLayout *sidebarLayout;
+  QHBoxLayout *buttonLayout;
   QHBoxLayout *bgLayout;
 
   QCheckBox *autoUpdateBox;
+
+  QPushButton *exportButton;
   QPushButton *refreshButton;
 
   QComboBox *zoomCombo;

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -55,6 +55,7 @@ private:
   ImageGridWidget *imageGridWidget;
 
   bool inUpdateFormCall;
+  bool inExportClickedCall;
 };
 
 extern TilemapViewer *tilemapViewer;

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.moc.hpp
@@ -47,6 +47,9 @@ private:
   QLineEdit *tileAddr;
   QLineEdit *screenAddr;
 
+  QCheckBox *overrideBackgroundColor;
+  QComboBox *customBgColorCombo;
+
   QLabel *tileInfo;
 
   ImageGridWidget* imageGridWidget;

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.cpp
@@ -222,7 +222,7 @@ void VramCanvas::buildDefaultPalette() {
   uint8_t pixel = 0;
 
   for(unsigned i = 0; i < nColors; i++) {
-    palette[i] = (pixel << 16) + (pixel << 8) + pixel;
+    palette[i] = qRgb(pixel, pixel, pixel);
     pixel += delta;
   }
 }
@@ -256,7 +256,7 @@ void VramCanvas::refresh() {
 }
 
 void VramCanvas::refresh2bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  QRgb* dest = (QRgb*)image.bits();
 
   for(unsigned ty = 0; ty < 256; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -276,7 +276,7 @@ void VramCanvas::refresh2bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refresh4bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  QRgb* dest = (QRgb*)image.bits();
 
   for(unsigned ty = 0; ty < 128; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -301,7 +301,7 @@ void VramCanvas::refresh4bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refresh8bpp(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  QRgb* dest = (QRgb*)image.bits();
 
   for(unsigned ty = 0; ty < 64; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {
@@ -334,7 +334,7 @@ void VramCanvas::refresh8bpp(const uint8_t *source) {
 }
 
 void VramCanvas::refreshMode7(const uint8_t *source) {
-  uint32_t *dest = (uint32_t*)image.bits();
+  QRgb* dest = (QRgb*)image.bits();
 
   for(unsigned ty = 0; ty < 16; ty++) {
     for(unsigned tx = 0; tx < 16; tx++) {

--- a/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/vram-viewer.moc.hpp
@@ -41,7 +41,7 @@ private:
   unsigned selectedColor;
   bool useCgram;
 
-  uint32_t palette[256];
+  QRgb palette[256];
 };
 
 class VramAddrItem : public QWidget {

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -48,9 +48,11 @@ using namespace ruby;
   #include "debugger/tools/memory.moc.hpp"
   #include "debugger/tools/properties.moc.hpp"
 
+  #include "debugger/ppu/base-renderer.hpp"
+  #include "debugger/ppu/tilemap-renderer.hpp"
+
   #include "debugger/ppu/cgram-widget.moc.hpp"
   #include "debugger/ppu/image-grid-widget.moc.hpp"
-  #include "debugger/ppu/tilemap-renderer.hpp"
 
   #include "debugger/ppu/vram-viewer.moc.hpp"
   #include "debugger/ppu/tilemap-viewer.moc.hpp"

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -49,12 +49,14 @@ using namespace ruby;
   #include "debugger/tools/properties.moc.hpp"
 
   #include "debugger/ppu/base-renderer.hpp"
+  #include "debugger/ppu/tile-renderer.hpp"
   #include "debugger/ppu/tilemap-renderer.hpp"
 
   #include "debugger/ppu/cgram-widget.moc.hpp"
   #include "debugger/ppu/image-grid-widget.moc.hpp"
 
   #include "debugger/ppu/vram-viewer.moc.hpp"
+  #include "debugger/ppu/tile-viewer.moc.hpp"
   #include "debugger/ppu/tilemap-viewer.moc.hpp"
   #include "debugger/ppu/oam-viewer.moc.hpp"
   #include "debugger/ppu/cgram-viewer.moc.hpp"


### PR DESCRIPTION
This pull request updates the Tilemap Viewer and adds a new window, Tile Viewer, to the debugger.

<br/>

Changes to the Tilemap Viewer:
 * Add an Export button to save the tilemap as a PNG image ([suggested by qwertymodo](https://github.com/devinacker/bsnes-plus/issues/143))
 * Allow user to override the background color ([suggested by qwertymodo](https://github.com/devinacker/bsnes-plus/issues/143))

<br/>

The Tile Viewer allows the user to view tiles within VRAM and the CPU bus. It uses ImageGridWidget to draw the tiles and the same tile rendering code as the Tilemap Viewer (as suggested by @devinacker some time ago).


Notable features of Tile Viewer include:
 * Export button to save tiles as PNG Image
 * The user can override the background color
 * User adjustable width ([suggested by qwertymodo](https://github.com/devinacker/bsnes-plus/issues/62#issuecomment-257656033))
 * "goto" buttons set the bit-depth when clicked
    * The goto buttons do not set the Bit Depth in mode 7 as the game could be changing the screen modes mid frame
 * Next/Previous address buttons to allow for easier tile searching

![zelda-text](https://user-images.githubusercontent.com/65687/32265965-145febe4-bf31-11e7-97c2-70579a82837a.png)

If everyone is happy with the Tile Viewer we can retire the old Vram Viewer window. 

---
Paging @devinacker: Is [this](https://github.com/devinacker/bsnes-plus/blob/cc38bdf81ab2bf8a9df3cf66c65561b49ddcfd37/bsnes/ui-qt/debugger/ppu/tile-renderer.cpp#L145-L161) the correct way to access the CPU bus?

<br/>

Paging @Optiroc: When you encounter merge conflicts, use my code instead of yours.

I was unable to test this push request with optiroc/master as there is no mingw build of QtWebEngine ([source](https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#windows)). Instead, I tested the code with commit e24f81e on Windows 7 Qt 5.9.0 x86-mingw32 and Qt 5.9.2 Archlinux x86_64