### PR TITLE
Compatibility improvement (and a minor bug fix)

### DIFF
--- a/bsnes/nall/snes/cartridge.hpp
+++ b/bsnes/nall/snes/cartridge.hpp
@@ -188,9 +188,10 @@ SNESCartridge::SNESCartridge(const uint8_t *data, unsigned size) {
     xml << "    <map mode='linear' address='c0-ff:0000-ffff' offset='000000'/>\n";
     xml << "  </rom>\n";
 
-    if(ram_size > 0) {
+    if(ram_size > 0) {//compatibility improvement(for hack rom). no commerical game (only Tales of Phantasia is ExHiROM ?) get affected
       xml << "  <ram size='" << hex(ram_size) << "'>\n";
-      xml << "    <map mode='linear' address='80-bf:6000-7fff'/>\n";
+      xml << "    <map mode='linear' address='20-3f:6000-7fff'/>\n";
+      xml << "    <map mode='linear' address='a0-bf:6000-7fff'/>\n";
       xml << "  </ram>\n";
     }
   } else if(mapper == SuperFXROM) {

--- a/bsnes/snes/alt/ppu-compatibility/memory/memory.cpp
+++ b/bsnes/snes/alt/ppu-compatibility/memory/memory.cpp
@@ -29,8 +29,9 @@ uint8 PPU::vram_mmio_read(uint16 addr) {
   return 0;
 }
 
+
 void PPU::vram_mmio_write(uint16 addr, uint8 data) {
-  if(regs.display_disabled == true) {
+  if(!SNES::config.blockInvalidVRAMAccess || regs.display_disabled == true) {//compatibility improvement . many translated games and hack roms need this
     memory::vram[addr] = data;
   } else {
     uint16 v = cpu.vcounter_past(6);

--- a/bsnes/snes/config/config.hpp
+++ b/bsnes/snes/config/config.hpp
@@ -4,6 +4,7 @@ struct Configuration {
   System::ExpansionPortDevice expansion_port;
   System::Region region;
   bool random;
+  bool blockInvalidVRAMAccess;
 
   struct CPU {
     unsigned version;

--- a/bsnes/snes/ppu/mmio/mmio.cpp
+++ b/bsnes/snes/ppu/mmio/mmio.cpp
@@ -38,7 +38,7 @@ uint8 PPU::vram_read(unsigned addr) {
 }
 
 void PPU::vram_write(unsigned addr, uint8 data) {
-  if(regs.display_disable || vcounter() >= (!regs.overscan ? 225 : 240)) {
+  if(!SNES::config.blockInvalidVRAMAccess || regs.display_disable || vcounter() >= (!regs.overscan ? 225 : 240)) {
     memory::vram[addr] = data;
   }
 }

--- a/bsnes/ui-qt/base/filebrowser.cpp
+++ b/bsnes/ui-qt/base/filebrowser.cpp
@@ -48,7 +48,7 @@ void FileBrowser::loadCartridge(CartridgeMode mode, signed filterIndex) {
     audio.clear();
     QString qfilename = QFileDialog::getOpenFileName(0,
       windowTitle(), defaultPath, string(
-        "SNES cartridges (*.sfc *.bs *.st *.gb *.sgb *.gbc", music.extensionList, reader.extensionList, reader.compressionList, ");;",
+        "SNES cartridges (*.sfc *.smc *.bs *.st *.gb *.sgb *.gbc", music.extensionList, reader.extensionList, reader.compressionList, ");;",
         "All files (*)"
       )
     );
@@ -63,7 +63,7 @@ void FileBrowser::loadCartridge(CartridgeMode mode, signed filterIndex) {
 
   setPath(defaultPath);
   setNameFilters(string()
-  << "SNES cartridges (*.sfc" << reader.extensionList << reader.compressionList << ")\n"
+  << "SNES cartridges (*.sfc *.smc" << reader.extensionList << reader.compressionList << ")\n"
   << "BS-X cartridges (*.bs" << reader.compressionList << ")\n"
   << "Sufami Turbo cartridges (*.st" << reader.compressionList << ")\n"
   << "Game Boy cartridges (*.gb *.sgb *.gbc" << reader.compressionList << ")\n"
@@ -131,6 +131,7 @@ string FileBrowser::resolveFilename(const string &path) {
   if(QDir(path).exists()) {
     string filter;
     if(striend(path, ".sfc")) filter = "*.sfc";
+    if(striend(path, ".smc")) filter = "*.smc";
     if(striend(path, ".bs" )) filter = "*.bs";
     if(striend(path, ".st" )) filter = "*.st";
     if(striend(path, ".gb" )) filter = "*.gb";
@@ -197,6 +198,7 @@ void FileBrowser::onAcceptCartridge(const string &path) {
       if(0);
       //file extension detection
       else if(striend(filename, ".sfc")) acceptNormal(filename);
+      else if(striend(filename, ".smc")) acceptNormal(filename);
       else if(striend(filename, ".bs"))  acceptBsx(filename);
       else if(striend(filename, ".st"))  acceptSufamiTurbo(filename);
       else if(striend(filename, ".gb"))  acceptSuperGameBoy(filename);

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -77,6 +77,7 @@ Configuration::Configuration() {
   attach(video.synchronize  = false, "video.synchronize");
 
   attach(video.autoHideFullscreenMenu = false, "video.autoHideFullscreenMenu");
+  attach(video.blockInvalidVRAMAccess = true, "video.blockInvalidVRAMAccess");
 
   attach(video.contrastAdjust   = 0,    "video.contrastAdjust");
   attach(video.brightnessAdjust = 0,    "video.brightnessAdjust");

--- a/bsnes/ui-qt/config.hpp
+++ b/bsnes/ui-qt/config.hpp
@@ -42,6 +42,7 @@ public:
     bool synchronize;
 
     bool autoHideFullscreenMenu;
+    bool blockInvalidVRAMAccess;
 
     signed contrastAdjust, brightnessAdjust, gammaAdjust, scanlineAdjust;
     bool enableGammaRamp;

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -302,7 +302,7 @@ void Debugger::synchronize() {
 
 void Debugger::echo(const char *message) {
   console->moveCursor(QTextCursor::End);
-  console->insertHtml(message);
+  console->insertHtml(QString::fromUtf8(message));
 }
 
 void Debugger::clear() {

--- a/bsnes/ui-qt/link/reader.cpp
+++ b/bsnes/ui-qt/link/reader.cpp
@@ -36,7 +36,7 @@ Reader::Reader() {
 
   if(opened()) {
     extensionList = string()
-    << " *.smc *.swc *.fig"
+    << " *.swc *.fig" // no need of snesreader to read *.smc? see line 17 and 18 for removing copier header  by komicakomica
     << " *.ufo *.gd3 *.gd7 *.dx2 *.mgd *.mgh"
     << " *.048 *.058 *.068 *.078 *.bin"
     << " *.usa *.eur *.jap *.aus *.bsx";

--- a/bsnes/ui-qt/settings/video.cpp
+++ b/bsnes/ui-qt/settings/video.cpp
@@ -12,7 +12,9 @@ VideoSettingsWindow::VideoSettingsWindow() {
   layout->addWidget(displayLabel);
 
   autoHideFullscreenMenu = new QCheckBox("Auto-hide menus when entering fullscreen mode");
+  blockInvalidVRAMAccess = new QCheckBox("BlockInvalidVRAMAccess");                         
   layout->addWidget(autoHideFullscreenMenu);
+  layout->addWidget(blockInvalidVRAMAccess);
 
   colorLabel = new QLabel("<b>Color Adjustment</b>");
   layout->addWidget(colorLabel);
@@ -148,6 +150,7 @@ VideoSettingsWindow::VideoSettingsWindow() {
   pixelShaderLayout->addWidget(shaderDefault, 0, 2);
 
   connect(autoHideFullscreenMenu, SIGNAL(stateChanged(int)), this, SLOT(autoHideFullscreenMenuToggle()));
+  connect(blockInvalidVRAMAccess, SIGNAL(stateChanged(int)), this, SLOT(blockInvalidVRAMAccessToggle()));
   connect(contrastSlider, SIGNAL(valueChanged(int)), this, SLOT(contrastAdjust(int)));
   connect(brightnessSlider, SIGNAL(valueChanged(int)), this, SLOT(brightnessAdjust(int)));
   connect(gammaSlider, SIGNAL(valueChanged(int)), this, SLOT(gammaAdjust(int)));
@@ -176,6 +179,7 @@ void VideoSettingsWindow::syncUi() {
   int n;
 
   autoHideFullscreenMenu->setChecked(config().video.autoHideFullscreenMenu);
+  blockInvalidVRAMAccess->setChecked(config().video.blockInvalidVRAMAccess);
 
   n = config().video.contrastAdjust;
   contrastValue->setText(string() << (n > 0 ? "+" : "") << n << "%");
@@ -216,6 +220,12 @@ void VideoSettingsWindow::syncUi() {
 
 void VideoSettingsWindow::autoHideFullscreenMenuToggle() {
   config().video.autoHideFullscreenMenu = autoHideFullscreenMenu->isChecked();
+}
+
+//by komicakomica
+void VideoSettingsWindow::blockInvalidVRAMAccessToggle() {
+  config().video.blockInvalidVRAMAccess = blockInvalidVRAMAccess->isChecked();
+  SNES::config.blockInvalidVRAMAccess = blockInvalidVRAMAccess->isChecked();
 }
 
 void VideoSettingsWindow::contrastAdjust(int value) {

--- a/bsnes/ui-qt/settings/video.moc.hpp
+++ b/bsnes/ui-qt/settings/video.moc.hpp
@@ -5,6 +5,7 @@ public:
   QVBoxLayout *layout;
   QLabel *displayLabel;
   QCheckBox *autoHideFullscreenMenu;
+  QCheckBox *blockInvalidVRAMAccess;//by komicakomica
   QLabel *colorLabel;
   QGridLayout *colorLayout;
   QLabel *contrastLabel;
@@ -47,6 +48,7 @@ public:
 
 private slots:
   void autoHideFullscreenMenuToggle();
+  void blockInvalidVRAMAccessToggle();//by komicakomica
   void contrastAdjust(int);
   void brightnessAdjust(int);
   void gammaAdjust(int);


### PR DESCRIPTION
This pull request adds a snes9x-style blockInvalidVRAMAccess option in video settings and makes sram mapping for ExHirom the same as Hirom . No commerical game (only Tales of Phantasia is ExHiROM ?) get affected.

Also a minor encoding bug in debug window is fixed. 