### PR TITLE
Update build to target Qt5

### DIFF
--- a/bsnes/ruby/ruby_impl.cpp
+++ b/bsnes/ruby/ruby_impl.cpp
@@ -2,7 +2,7 @@
 
 #if defined(VIDEO_QTOPENGL) || defined(VIDEO_QTRASTER)
   #include <QApplication>
-  #include <QtGui>
+  #include <QtWidgets>
 #endif
 
 #if defined(VIDEO_QTOPENGL)

--- a/bsnes/ui-qt/Makefile
+++ b/bsnes/ui-qt/Makefile
@@ -1,4 +1,4 @@
-qtlibs := $(strip QtCore QtGui $(if $(findstring osx,$(platform)),QtOpenGL))
+qtlibs := $(strip QtCore QtGui QtWidgets $(if $(findstring osx,$(platform)),QtOpenGL))
 include $(ui)/template/Makefile
 
 ui_objects := ui-main ui-base ui-cartridge ui-debugger ui-input ui-movie ui-settings ui-state ui-tools

--- a/bsnes/ui-qt/settings/input.cpp
+++ b/bsnes/ui-qt/settings/input.cpp
@@ -17,7 +17,7 @@ InputSettingsWindow::InputSettingsWindow() {
   list->setAllColumnsShowFocus(true);
   list->setSortingEnabled(false);
   list->header()->hide();
-  list->header()->setResizeMode(QHeaderView::ResizeToContents);
+  list->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
   layout->addWidget(list);
 
   modifierEnable = new QCheckBox("Allow modifier keys to be assigned standalone");

--- a/bsnes/ui-qt/template/Makefile
+++ b/bsnes/ui-qt/template/Makefile
@@ -30,14 +30,14 @@ ifeq ($(platform),x)
   qtlib := `pkg-config --libs $(qtlibs)`
 else ifeq ($(platform),osx)
   ifeq ($(qtpath),)
-    qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/4/Headers)
+    qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/5/Headers)
     qtlib := -L/Library/Frameworks
   else
     qtinc := -I$(qtpath)/include
-    qtinc += $(foreach lib,$(qtlibs),-I$(qtpath)/lib/$(lib).framework/Versions/4/Headers)
+    qtinc += $(foreach lib,$(qtlibs),-I$(qtpath)/lib/$(lib).framework/Versions/5/Headers)
     qtlib := -L$(qtpath)/lib -F$(qtpath)/lib
   endif
-  qtinc += $(foreach lib,$(qtlibs),-I/usr/local/lib/$(lib).framework/Versions/4/Headers)
+  qtinc += $(foreach lib,$(qtlibs),-I/usr/local/lib/$(lib).framework/Versions/5/Headers)
   qtlib += $(foreach lib,$(qtlibs),-framework $(lib))
   qtlib += -framework Carbon
   qtlib += -framework CoreFoundation
@@ -61,10 +61,10 @@ else ifeq ($(platform),win)
   qtlib := -L$(qtpath)/lib
   qtlib += -L$(qtpath)/plugins/imageformats
 
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
   qtlib += -lmingw32 -lqtmain -lcomdlg32 -loleaut32 -limm32 -lwinmm
   qtlib += -lwinspool -lmsimg32 -lole32 -ladvapi32 -lws2_32 -luuid -lgdi32
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
 
   # optional image-file support:
   # qtlib += -lqjpeg -lqmng

--- a/bsnes/ui-qt/template/Makefile
+++ b/bsnes/ui-qt/template/Makefile
@@ -26,8 +26,14 @@ ifeq ($(rcc),)
 endif
 
 ifeq ($(platform),x)
-  qtinc := `pkg-config --cflags $(qtlibs)`
-  qtlib := `pkg-config --libs $(qtlibs)`
+  qtlibs := $(subst Qt,Qt5,$(qtlibs))
+  qtinc := $(shell pkg-config --cflags $(qtlibs))
+  qtlib := $(shell pkg-config --libs $(qtlibs))
+
+  ifneq ($(filter reduce_relocations, $(shell pkg-config --variable qt_config $(qtlibs))),)
+    qtinc += -fPIC
+    qtlib += -fPIC
+  endif
 else ifeq ($(platform),osx)
   ifeq ($(qtpath),)
     qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/5/Headers)

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -3,7 +3,7 @@
 #define QT_THREAD_SUPPORT
 
 #include <QApplication>
-#include <QtGui>
+#include <QtWidgets>
 //Q_IMPORT_PLUGIN(QJpegPlugin)
 //Q_IMPORT_PLUGIN(QMngPlugin)
 

--- a/snesfilter/Makefile
+++ b/snesfilter/Makefile
@@ -1,6 +1,6 @@
 include nall/Makefile
 
-qtlibs := QtCore QtGui
+qtlibs := QtCore QtGui QtWidgets
 include nall/qt/Makefile
 
 c     := $(compiler) -xc -std=gnu99

--- a/snesfilter/nall/qt/Makefile
+++ b/snesfilter/nall/qt/Makefile
@@ -59,10 +59,10 @@ else ifeq ($(platform),win)
   qtlib := -L$(qtpath)/lib
   qtlib += -L$(qtpath)/plugins/imageformats
 
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
   qtlib += -lmingw32 -lqtmain -lcomdlg32 -loleaut32 -limm32 -lwinmm
   qtlib += -lwinspool -lmsimg32 -lole32 -ladvapi32 -lws2_32 -luuid -lgdi32
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
 
   # optional image-file support:
   # qtlib += -lqjpeg -lqmng

--- a/snesfilter/nall/qt/Makefile
+++ b/snesfilter/nall/qt/Makefile
@@ -26,8 +26,14 @@ ifeq ($(rcc),)
 endif
 
 ifeq ($(platform),x)
-  qtinc := `pkg-config --cflags $(qtlibs)`
-  qtlib := `pkg-config --libs $(qtlibs)`
+  qtlibs := $(subst Qt,Qt5,$(qtlibs))
+  qtinc := $(shell pkg-config --cflags $(qtlibs))
+  qtlib := $(shell pkg-config --libs $(qtlibs))
+
+  ifneq ($(filter reduce_relocations, $(shell pkg-config --variable qt_config $(qtlibs))),)
+    qtinc += -fPIC
+    qtlib += -fPIC
+  endif
 else ifeq ($(platform),osx)
   ifeq ($(qtpath),)
     qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/4/Headers)

--- a/snesfilter/snesfilter.cpp
+++ b/snesfilter/snesfilter.cpp
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #define QT_CORE_LIB
-#include <QtGui>
+#include <QtWidgets>
 
 #include <nall/config.hpp>
 #include <nall/detect.hpp>

--- a/snesreader/Makefile
+++ b/snesreader/Makefile
@@ -1,6 +1,6 @@
 include nall/Makefile
 
-qtlibs := QtCore QtGui
+qtlibs := QtCore QtGui QtWidgets
 include nall/qt/Makefile
 
 c     := $(compiler) -xc -std=gnu99

--- a/snesreader/nall/qt/Makefile
+++ b/snesreader/nall/qt/Makefile
@@ -59,10 +59,10 @@ else ifeq ($(platform),win)
   qtlib := -L$(qtpath)/lib
   qtlib += -L$(qtpath)/plugins/imageformats
 
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
   qtlib += -lmingw32 -lqtmain -lcomdlg32 -loleaut32 -limm32 -lwinmm
   qtlib += -lwinspool -lmsimg32 -lole32 -ladvapi32 -lws2_32 -luuid -lgdi32
-  qtlib += $(foreach lib,$(qtlibs),-l$(lib)4)
+  qtlib += $(subst -lQt,-lQt5,$(foreach lib,$(qtlibs),-l$(lib)))
 
   # optional image-file support:
   # qtlib += -lqjpeg -lqmng

--- a/snesreader/nall/qt/Makefile
+++ b/snesreader/nall/qt/Makefile
@@ -26,8 +26,14 @@ ifeq ($(rcc),)
 endif
 
 ifeq ($(platform),x)
-  qtinc := `pkg-config --cflags $(qtlibs)`
-  qtlib := `pkg-config --libs $(qtlibs)`
+  qtlibs := $(subst Qt,Qt5,$(qtlibs))
+  qtinc := $(shell pkg-config --cflags $(qtlibs))
+  qtlib := $(shell pkg-config --libs $(qtlibs))
+
+  ifneq ($(filter reduce_relocations, $(shell pkg-config --variable qt_config $(qtlibs))),)
+    qtinc += -fPIC
+    qtlib += -fPIC
+  endif
 else ifeq ($(platform),osx)
   ifeq ($(qtpath),)
     qtinc := $(foreach lib,$(qtlibs),-I/Library/Frameworks/$(lib).framework/Versions/4/Headers)

--- a/snesreader/snesreader.cpp
+++ b/snesreader/snesreader.cpp
@@ -11,7 +11,7 @@
 extern "C" char* uncompressStream(int, int);  //micro-bunzip
 
 #define QT_CORE_LIB
-#include <QtGui>
+#include <QtWidgets>
 
 #include <nall/file.hpp>
 #include <nall/string.hpp>


### PR DESCRIPTION
Contrary to my report in https://github.com/devinacker/bsnes-plus/issues/146 it seems like it actually did take a bit of modification to update to Qt5 (I think my previous attempt was just building against Qt4 which it was still managing to find in my %PATH%).  This should properly update everything, at least for the Windows/MinGW build (which was the only one I was able to test).