### PR TITLE
Capture Unfiltered Screenshots

### DIFF
--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -92,6 +92,8 @@ Configuration::Configuration() {
   attach(video.cropRight  = 0, "video.cropRight");
   attach(video.cropBottom = 0, "video.cropBottom");
 
+  attach(video.unfilteredScreenshot = true, "video.unfilteredScreenshot");
+
   attach(video.windowed.correctAspectRatio = true, "video.windowed.correctAspectRatio");
   attach(video.windowed.multiplier         =    2, "video.windowed.multiplier");
   attach(video.windowed.region             =    0, "video.windowed.region");

--- a/bsnes/ui-qt/config.hpp
+++ b/bsnes/ui-qt/config.hpp
@@ -52,6 +52,8 @@ public:
     unsigned cropRight;
     unsigned cropBottom;
 
+    bool unfilteredScreenshot;
+
     struct Context {
       bool correctAspectRatio;
       unsigned multiplier, region;

--- a/bsnes/ui-qt/interface.cpp
+++ b/bsnes/ui-qt/interface.cpp
@@ -22,6 +22,8 @@ void Interface::video_refresh(const uint16_t *data, unsigned width, unsigned hei
     if(!overscan) data -= 7 * 1024;
   }
 
+  if(saveScreenshot == true) captureScreenshot(filter.renderUnfilteredScreenshot(data, pitch, width, height));
+
   //scale display.crop* values from percentage-based (0-100%) to exact pixel sizes (width, height)
   unsigned cropLeft = (double)display.cropLeft / 100.0 * width;
   unsigned cropTop = (double)display.cropTop / 100.0 * height;
@@ -40,7 +42,6 @@ void Interface::video_refresh(const uint16_t *data, unsigned width, unsigned hei
     filter.render(output, outpitch, data, pitch, width, height);
     video.unlock();
     video.refresh();
-    if(saveScreenshot == true) captureScreenshot(output, outpitch, outwidth, outheight);
   }
 
   state.frame();
@@ -76,9 +77,10 @@ void Interface::message(const string &text) {
   QMessageBox::information(mainWindow, "bsnes", QString::fromUtf8(text));
 }
 
-void Interface::captureScreenshot(uint32_t *data, unsigned pitch, unsigned width, unsigned height) {
+void Interface::captureScreenshot(const QImage& image) {
   saveScreenshot = false;
-  QImage image((const unsigned char*)data, width, height, pitch, QImage::Format_RGB32);
+
+  if(image.isNull()) return;
 
   string filename = nall::basename(cartridge.fileName);
   time_t systemTime = time(0);

--- a/bsnes/ui-qt/interface.cpp
+++ b/bsnes/ui-qt/interface.cpp
@@ -22,7 +22,9 @@ void Interface::video_refresh(const uint16_t *data, unsigned width, unsigned hei
     if(!overscan) data -= 7 * 1024;
   }
 
-  if(saveScreenshot == true) captureScreenshot(filter.renderUnfilteredScreenshot(data, pitch, width, height));
+  if(saveScreenshot == true && config().video.unfilteredScreenshot == true) {
+    captureScreenshot(filter.renderUnfilteredScreenshot(data, pitch, width, height));
+  }
 
   //scale display.crop* values from percentage-based (0-100%) to exact pixel sizes (width, height)
   unsigned cropLeft = (double)display.cropLeft / 100.0 * width;
@@ -42,6 +44,10 @@ void Interface::video_refresh(const uint16_t *data, unsigned width, unsigned hei
     filter.render(output, outpitch, data, pitch, width, height);
     video.unlock();
     video.refresh();
+
+    if(saveScreenshot == true && config().video.unfilteredScreenshot == false) {
+      captureScreenshot(QImage((const unsigned char*)output, outwidth, outheight, outpitch, QImage::Format_RGB32));
+    }
   }
 
   state.frame();

--- a/bsnes/ui-qt/interface.hpp
+++ b/bsnes/ui-qt/interface.hpp
@@ -8,7 +8,7 @@ public:
   void message(const string &text);
 
   Interface();
-  void captureScreenshot(uint32_t*, unsigned, unsigned, unsigned);
+  void captureScreenshot(const QImage&);
   void captureSPC();
   bool saveScreenshot;
   bool framesUpdated;

--- a/bsnes/ui-qt/link/filter.cpp
+++ b/bsnes/ui-qt/link/filter.cpp
@@ -198,18 +198,41 @@ void Filter::render(
 QImage Filter::renderUnfilteredScreenshot(
   const uint16_t *input, unsigned pitch, unsigned width, unsigned height
 ) {
-  QImage image(width, height, QImage::Format_RGB32);
+  unsigned outWidth = width;
+  unsigned outHeight = height;
+  bool doubleHeight = false;
+  bool doubleWidth = false;
+
+  if(width > 256 && height <= 240) {
+    outHeight *= 2;
+    doubleHeight = true;
+  }
+  else if(width <= 256 && height > 240) {
+    outWidth *= 2;
+    doubleWidth = true;
+  }
+
+  QImage image(outWidth, outHeight, QImage::Format_RGB32);
   if(image.isNull()) return image;
 
   pitch >>= 1;
-  unsigned outpitch = image.bytesPerLine() / sizeof(QRgb);
+  unsigned wordsPerScanline = image.bytesPerLine() / sizeof(QRgb);
+  unsigned outpitch = doubleHeight ? wordsPerScanline * 2 : wordsPerScanline;
+
   QRgb* output = (QRgb*)image.bits();
 
   for(unsigned y = 0; y < height; y++) {
     const uint16_t *in = input + y * pitch;
-    QRgb *out = output + y * outpitch;
+    QRgb *scanline = output + y * outpitch;
+    QRgb *out = scanline;
+
     for(unsigned x = 0; x < width; x++) {
-      *out++ = colortable[*in++];
+      if(doubleWidth) *out++ = colortable[*in];
+      *out++ = colortable[*in];
+      in++;
+    }
+    if(doubleHeight) {
+      memcpy(scanline + wordsPerScanline, scanline, wordsPerScanline * sizeof(QRgb));
     }
   }
 

--- a/bsnes/ui-qt/link/filter.cpp
+++ b/bsnes/ui-qt/link/filter.cpp
@@ -195,6 +195,27 @@ void Filter::render(
   }
 }
 
+QImage Filter::renderUnfilteredScreenshot(
+  const uint16_t *input, unsigned pitch, unsigned width, unsigned height
+) {
+  QImage image(width, height, QImage::Format_RGB32);
+  if(image.isNull()) return image;
+
+  pitch >>= 1;
+  unsigned outpitch = image.bytesPerLine() / sizeof(QRgb);
+  QRgb* output = (QRgb*)image.bits();
+
+  for(unsigned y = 0; y < height; y++) {
+    const uint16_t *in = input + y * pitch;
+    QRgb *out = output + y * outpitch;
+    for(unsigned x = 0; x < width; x++) {
+      *out++ = colortable[*in++];
+    }
+  }
+
+  return image;
+}
+
 QWidget* Filter::settings() {
   if(opened() && renderer > 0) {
     return dl_settings(renderer);

--- a/bsnes/ui-qt/link/filter.hpp
+++ b/bsnes/ui-qt/link/filter.hpp
@@ -38,6 +38,7 @@ public:
   void colortable_update();
   void size(unsigned&, unsigned&, unsigned, unsigned);
   void render(uint32_t*, unsigned, const uint16_t*, unsigned, unsigned, unsigned);
+  QImage renderUnfilteredScreenshot(const uint16_t*, unsigned, unsigned, unsigned);
   QWidget* settings();
 
   Filter();

--- a/bsnes/ui-qt/settings/video.cpp
+++ b/bsnes/ui-qt/settings/video.cpp
@@ -147,6 +147,13 @@ VideoSettingsWindow::VideoSettingsWindow() {
   shaderDefault = new QPushButton("Default");
   pixelShaderLayout->addWidget(shaderDefault, 0, 2);
 
+  miscellaneousLabel = new QLabel("<b>Miscellaneous</b>");
+  layout->addWidget(miscellaneousLabel);
+
+  unfilteredScreenshot = new QCheckBox("Save Unfiltered Screenshots");
+  layout->addWidget(unfilteredScreenshot);
+
+
   connect(autoHideFullscreenMenu, SIGNAL(stateChanged(int)), this, SLOT(autoHideFullscreenMenuToggle()));
   connect(contrastSlider, SIGNAL(valueChanged(int)), this, SLOT(contrastAdjust(int)));
   connect(brightnessSlider, SIGNAL(valueChanged(int)), this, SLOT(brightnessAdjust(int)));
@@ -159,6 +166,7 @@ VideoSettingsWindow::VideoSettingsWindow() {
   connect(cropBottomSlider, SIGNAL(valueChanged(int)), this, SLOT(cropBottomAdjust(int)));
   connect(shaderSelect, SIGNAL(released()), this, SLOT(selectShader()));
   connect(shaderDefault, SIGNAL(released()), this, SLOT(defaultShader()));
+  connect(unfilteredScreenshot, SIGNAL(stateChanged(int)), this, SLOT(unfilteredScreenshotToggle(int)));
 
   syncUi();
 }
@@ -212,6 +220,8 @@ void VideoSettingsWindow::syncUi() {
   cropBottomSlider->setSliderPosition(n);
 
   shaderValue->setText(config().path.shader);
+
+  unfilteredScreenshot->setChecked(config().video.unfilteredScreenshot);
 }
 
 void VideoSettingsWindow::autoHideFullscreenMenuToggle() {
@@ -291,4 +301,9 @@ void VideoSettingsWindow::assignShader(const string &filename) {
     syncUi();
     utility.updatePixelShader();
   }
+}
+
+void VideoSettingsWindow::unfilteredScreenshotToggle(int state) {
+  config().video.unfilteredScreenshot = (state == Qt::Checked);
+  syncUi();
 }

--- a/bsnes/ui-qt/settings/video.moc.hpp
+++ b/bsnes/ui-qt/settings/video.moc.hpp
@@ -40,6 +40,8 @@ public:
   QLineEdit *shaderValue;
   QPushButton *shaderSelect;
   QPushButton *shaderDefault;
+  QLabel *miscellaneousLabel;
+  QCheckBox *unfilteredScreenshot;
 
   void synchronizePixelShaderSettings();
   void syncUi();
@@ -58,6 +60,7 @@ private slots:
   void cropBottomAdjust(int);
   void selectShader();
   void defaultShader();
+  void unfilteredScreenshotToggle(int);
 
 private:
   void assignShader(const string &filename);


### PR DESCRIPTION
This push request adds a configuration option that allows the user to capture unfiltered screenshots.

The setting `video.unfilteredScreenshot` (enabled by default) will:
 * Bypass the overscan, scanline filter and video filter settings when capturing screenshots.
 * Double the height or width of the unfiltered screenshot as necessary (tested in both accuracy and comparability builds on 256x224, 512x224, 256x448 and 512x448 screen modes).

When `video.unfilteredScreenshot` is false, the screenshots will be taken after the video filer as per the original behaviour. 

Unfiltered screenshots still honour the color adjustment settings.

Fixes [#151](https://github.com/devinacker/bsnes-plus/issues/151).