### PR TITLE
Add support for the NTT Data Keypad

### DIFF
--- a/bsnes/snes/input/input.cpp
+++ b/bsnes/snes/input/input.cpp
@@ -209,6 +209,28 @@ uint8 Input::port_read(bool portnumber) {
         case 31: return 0;
       }
     } //case Device::Justifier(s)
+
+    case Device::NTTDataKeypad: {
+      if(cpu.joylatch() == 0) {
+        if(p.counter0 >= 32) return 1;
+
+		// Id bits for NTTDataKeypad
+		if(p.counter0 >= 12 && p.counter0 <= 15) {
+			if(p.counter0 == 13) {
+				p.counter0++;
+				return 1;
+			}
+			p.counter0++;
+			return 0;
+		}
+
+        return system.interface->input_poll(portnumber, p.device, 0, p.counter0++);
+      } else {
+        return system.interface->input_poll(portnumber, p.device, 0, 0);
+      }
+    } //case Device::NTTDataKeypad
+
+
   } //switch(p.device)
 
   //no device connected

--- a/bsnes/snes/input/input.hpp
+++ b/bsnes/snes/input/input.hpp
@@ -8,6 +8,7 @@ public:
     SuperScope,
     Justifier,
     Justifiers,
+    NTTDataKeypad,
   };
 
   enum class JoypadID : unsigned {

--- a/bsnes/snes/input/input.hpp
+++ b/bsnes/snes/input/input.hpp
@@ -29,6 +29,16 @@ public:
     X = 0, Y = 1, Trigger = 2, Start = 3,
   };
 
+  enum class NTTDataKeypadID : unsigned {
+    B  =  0, Y    =  1, Select =  2, Start =  3,
+    Up =  4, Down =  5, Left   =  6, Right =  7,
+    A  =  8, X    =  9, L      = 10, R     = 11,
+	Digit0 = 16, Digit1 = 17, Digit2 = 18, Digit3 = 19, Digit4 = 20,
+	Digit5 = 21, Digit6 = 22, Digit7 = 23, Digit8 = 24, Digit9 = 25,
+	Star = 26, Hash = 27, Period = 28, C = 29, Hangup = 31,
+  };
+
+
   uint8 port_read(bool port);
   void port_set_device(bool port, Device device);
   void init();

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -48,6 +48,7 @@ MainWindow::MainWindow() {
   system_port1->addAction(system_port1_asciipad = new RadioAction("&asciiPad", 0));
   system_port1->addAction(system_port1_multitap = new RadioAction("&Multitap", 0));
   system_port1->addAction(system_port1_mouse = new RadioAction("&Mouse", 0));
+  system_port1->addAction(system_port1_nttdatakeypad = new RadioAction("NTT Data &Keypad", 0));
 
   system_port2 = system->addMenu("Controller Port &2");
   system_port2->addAction(system_port2_none = new RadioAction("&None", 0));
@@ -268,6 +269,7 @@ MainWindow::MainWindow() {
   connect(system_port1_asciipad, SIGNAL(triggered()), this, SLOT(setPort1Asciipad()));
   connect(system_port1_multitap, SIGNAL(triggered()), this, SLOT(setPort1Multitap()));
   connect(system_port1_mouse, SIGNAL(triggered()), this, SLOT(setPort1Mouse()));
+  connect(system_port1_nttdatakeypad, SIGNAL(triggered()), this, SLOT(setPort1NTTDataKeypad()));
   connect(system_port2_none, SIGNAL(triggered()), this, SLOT(setPort2None()));
   connect(system_port2_gamepad, SIGNAL(triggered()), this, SLOT(setPort2Gamepad()));
   connect(system_port2_asciipad, SIGNAL(triggered()), this, SLOT(setPort2Asciipad()));
@@ -335,6 +337,7 @@ void MainWindow::syncUi() {
   system_port1_asciipad->setChecked  (config().input.port1 == ControllerPort1::Asciipad);
   system_port1_multitap->setChecked  (config().input.port1 == ControllerPort1::Multitap);
   system_port1_mouse->setChecked     (config().input.port1 == ControllerPort1::Mouse);
+  system_port1_nttdatakeypad->setChecked(config().input.port1 == ControllerPort1::NTTDataKeypad);
 
   system_port2_none->setChecked      (config().input.port2 == ControllerPort2::None);
   system_port2_gamepad->setChecked   (config().input.port2 == ControllerPort2::Gamepad);
@@ -466,6 +469,12 @@ void MainWindow::setPort1Multitap() {
 void MainWindow::setPort1Mouse() {
   config().input.port1 = ControllerPort1::Mouse;
   SNES::config.controller_port1 = SNES::Input::Device::Mouse;
+  utility.updateControllers();
+}
+
+void MainWindow::setPort1NTTDataKeypad() {
+  config().input.port1 = ControllerPort1::NTTDataKeypad;
+  SNES::config.controller_port1 = SNES::Input::Device::NTTDataKeypad;
   utility.updateControllers();
 }
 

--- a/bsnes/ui-qt/base/main.moc.hpp
+++ b/bsnes/ui-qt/base/main.moc.hpp
@@ -38,6 +38,7 @@ public:
       RadioAction *system_port1_asciipad;
       RadioAction *system_port1_multitap;
       RadioAction *system_port1_mouse;
+      RadioAction *system_port1_nttdatakeypad;
     QMenu *system_port2;
       RadioAction *system_port2_none;
       RadioAction *system_port2_gamepad;
@@ -125,6 +126,7 @@ public slots:
   void setPort1Asciipad();
   void setPort1Multitap();
   void setPort1Mouse();
+  void setPort1NTTDataKeypad();
   void setPort2None();
   void setPort2Gamepad();
   void setPort2Asciipad();

--- a/bsnes/ui-qt/input/controller.cpp
+++ b/bsnes/ui-qt/input/controller.cpp
@@ -365,23 +365,38 @@ int16_t NTTDataKeypad::status(unsigned index, unsigned id) const {
     //block up+down and left+right combinations:
     //a real gamepad has a pivot in the D-pad that makes this impossible;
     //some software titles will crash if up+down or left+right are detected
-    if(id == (unsigned)SNES::Input::JoypadID::Down && up.cachedState) return 0;
-    if(id == (unsigned)SNES::Input::JoypadID::Right && left.cachedState) return 0;
+    if(id == (unsigned)SNES::Input::NTTDataKeypadID::Down && up.cachedState) return 0;
+    if(id == (unsigned)SNES::Input::NTTDataKeypadID::Right && left.cachedState) return 0;
   }
 
-  switch((SNES::Input::JoypadID)id) {
-    case SNES::Input::JoypadID::Up: return up.cachedState;
-    case SNES::Input::JoypadID::Down: return down.cachedState;
-    case SNES::Input::JoypadID::Left: return left.cachedState;
-    case SNES::Input::JoypadID::Right: return right.cachedState;
-    case SNES::Input::JoypadID::A: return a.cachedState | turboA.cachedState;
-    case SNES::Input::JoypadID::B: return b.cachedState | turboB.cachedState;
-    case SNES::Input::JoypadID::X: return x.cachedState | turboX.cachedState;
-    case SNES::Input::JoypadID::Y: return y.cachedState | turboY.cachedState;
-    case SNES::Input::JoypadID::L: return l.cachedState | turboL.cachedState;
-    case SNES::Input::JoypadID::R: return r.cachedState | turboR.cachedState;
-    case SNES::Input::JoypadID::Select: return select.cachedState;
-    case SNES::Input::JoypadID::Start: return start.cachedState;
+  switch((SNES::Input::NTTDataKeypadID)id) {
+    case SNES::Input::NTTDataKeypadID::Up: return up.cachedState;
+    case SNES::Input::NTTDataKeypadID::Down: return down.cachedState;
+    case SNES::Input::NTTDataKeypadID::Left: return left.cachedState;
+    case SNES::Input::NTTDataKeypadID::Right: return right.cachedState;
+    case SNES::Input::NTTDataKeypadID::A: return a.cachedState | turboA.cachedState;
+    case SNES::Input::NTTDataKeypadID::B: return b.cachedState | turboB.cachedState;
+    case SNES::Input::NTTDataKeypadID::X: return x.cachedState | turboX.cachedState;
+    case SNES::Input::NTTDataKeypadID::Y: return y.cachedState | turboY.cachedState;
+    case SNES::Input::NTTDataKeypadID::L: return l.cachedState | turboL.cachedState;
+    case SNES::Input::NTTDataKeypadID::R: return r.cachedState | turboR.cachedState;
+    case SNES::Input::NTTDataKeypadID::Select: return select.cachedState;
+    case SNES::Input::NTTDataKeypadID::Start: return start.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit0: return digit0.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit1: return digit1.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit2: return digit2.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit3: return digit3.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit4: return digit4.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit5: return digit5.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit6: return digit6.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit7: return digit7.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit8: return digit8.cachedState;
+    case SNES::Input::NTTDataKeypadID::Digit9: return digit9.cachedState;
+    case SNES::Input::NTTDataKeypadID::Star: return star.cachedState;
+    case SNES::Input::NTTDataKeypadID::Hash: return hash.cachedState;
+    case SNES::Input::NTTDataKeypadID::Period: return period.cachedState;
+    case SNES::Input::NTTDataKeypadID::C: return c.cachedState;
+    case SNES::Input::NTTDataKeypadID::Hangup: return hangup.cachedState;
   }
   return 0;
 }

--- a/bsnes/ui-qt/input/controller.cpp
+++ b/bsnes/ui-qt/input/controller.cpp
@@ -360,6 +360,111 @@ port1(port1_), port2(port2_) {
 
 //
 
+int16_t NTTDataKeypad::status(unsigned index, unsigned id) const {
+  if(config().input.allowInvalidInput == false) {
+    //block up+down and left+right combinations:
+    //a real gamepad has a pivot in the D-pad that makes this impossible;
+    //some software titles will crash if up+down or left+right are detected
+    if(id == (unsigned)SNES::Input::JoypadID::Down && up.cachedState) return 0;
+    if(id == (unsigned)SNES::Input::JoypadID::Right && left.cachedState) return 0;
+  }
+
+  switch((SNES::Input::JoypadID)id) {
+    case SNES::Input::JoypadID::Up: return up.cachedState;
+    case SNES::Input::JoypadID::Down: return down.cachedState;
+    case SNES::Input::JoypadID::Left: return left.cachedState;
+    case SNES::Input::JoypadID::Right: return right.cachedState;
+    case SNES::Input::JoypadID::A: return a.cachedState | turboA.cachedState;
+    case SNES::Input::JoypadID::B: return b.cachedState | turboB.cachedState;
+    case SNES::Input::JoypadID::X: return x.cachedState | turboX.cachedState;
+    case SNES::Input::JoypadID::Y: return y.cachedState | turboY.cachedState;
+    case SNES::Input::JoypadID::L: return l.cachedState | turboL.cachedState;
+    case SNES::Input::JoypadID::R: return r.cachedState | turboR.cachedState;
+    case SNES::Input::JoypadID::Select: return select.cachedState;
+    case SNES::Input::JoypadID::Start: return start.cachedState;
+  }
+  return 0;
+}
+
+
+NTTDataKeypad::NTTDataKeypad(unsigned category, const char *label, const char *configName) :
+InputGroup(category, label),
+up("Up", string() << "input." << configName << ".up"),
+down("Down", string() << "input." << configName << ".down"),
+left("Left", string() << "input." << configName << ".left"),
+right("Right", string() << "input." << configName << ".right"),
+b("B", string() << "input." << configName << ".b"),
+a("A", string() << "input." << configName << ".a"),
+y("Y", string() << "input." << configName << ".y"),
+x("X", string() << "input." << configName << ".x"),
+l("L", string() << "input." << configName << ".l"),
+r("R", string() << "input." << configName << ".r"),
+select("Select", string() << "input." << configName << ".select"),
+start("Start", string() << "input." << configName << ".start"),
+digit0("0", string() << "input." << configName << ".0"),
+digit1("1", string() << "input." << configName << ".1"),
+digit2("2", string() << "input." << configName << ".2"),
+digit3("3", string() << "input." << configName << ".3"),
+digit4("4", string() << "input." << configName << ".4"),
+digit5("5", string() << "input." << configName << ".5"),
+digit6("6", string() << "input." << configName << ".6"),
+digit7("7", string() << "input." << configName << ".7"),
+digit8("8", string() << "input." << configName << ".8"),
+digit9("9", string() << "input." << configName << ".9"),
+star("*", string() << "input." << configName << ".star"),
+hash("#", string() << "input." << configName << ".hash"),
+period(".", string() << "input." << configName << ".period"),
+c("C", string() << "input." << configName << ".c"),
+hangup("Hang up", string() << "input." << configName << ".hangup"),
+turboB("Turbo B", string() << "input." << configName << ".turboB"),
+turboA("Turbo A", string() << "input." << configName << ".turboA"),
+turboY("Turbo Y", string() << "input." << configName << ".turboY"),
+turboX("Turbo X", string() << "input." << configName << ".turboX"),
+turboL("Turbo L", string() << "input." << configName << ".turboL"),
+turboR("Turbo R", string() << "input." << configName << ".turboR") {
+  attach(&up); attach(&down); attach(&left); attach(&right);
+  attach(&b); attach(&a); attach(&y); attach(&x);
+  attach(&l); attach(&r); attach(&select); attach(&start);
+  attach(&digit0); attach(&digit1); attach(&digit2); attach(&digit3);
+  attach(&digit4); attach(&digit5); attach(&digit6); attach(&digit7);
+  attach(&digit8); attach(&digit9); attach(&star); attach(&hash);
+  attach(&period); attach(&c); attach(&hangup);
+  attach(&turboB); attach(&turboA); attach(&turboY); attach(&turboX);
+  attach(&turboL); attach(&turboR);
+
+  if(this == &nttdatakeypad1) {
+    up.name = "KB0::Up";
+    down.name = "KB0::Down";
+    left.name = "KB0::Left";
+    right.name = "KB0::Right";
+    b.name = "KB0::Z";
+    a.name = "KB0::X";
+    y.name = "KB0::A";
+    x.name = "KB0::S";
+    l.name = "KB0::D";
+    r.name = "KB0::C";
+    select.name = "KB0::Apostrophe";
+    start.name = "KB0::Return";
+    digit0.name = "KB0::Num0";
+    digit1.name = "KB0::Num1";
+    digit2.name = "KB0::Num2";
+    digit3.name = "KB0::Num3";
+    digit4.name = "KB0::Num4";
+    digit5.name = "KB0::Num5";
+    digit6.name = "KB0::Num6";
+    digit7.name = "KB0::Num7";
+    digit8.name = "KB0::Num8";
+    digit9.name = "KB0::Num9";
+    star.name = "KB0::Multiply";
+    hash.name = "KB0::N";
+    period.name = "KB0::Period";
+    c.name = "KB0::Backspace";
+    hangup.name = "KB0::End";
+  }
+}
+
+//
+
 Gamepad gamepad1(InputCategory::Port1, "Gamepad", "gamepad1");
 Asciipad asciipad1(InputCategory::Port1, "asciiPad", "asciipad1");
 Gamepad multitap1a(InputCategory::Port1, "Multitap - Port 1", "multitap1a");
@@ -368,6 +473,7 @@ Gamepad multitap1c(InputCategory::Port1, "Multitap - Port 3", "multitap1c");
 Gamepad multitap1d(InputCategory::Port1, "Multitap - Port 4", "multitap1d");
 Multitap multitap1(multitap1a, multitap1b, multitap1c, multitap1d);
 Mouse mouse1(InputCategory::Port1, "Mouse", "mouse1");
+NTTDataKeypad nttdatakeypad1(InputCategory::Port1, "NTT Data Keypad", "nttdatakeypad1");
 
 Gamepad gamepad2(InputCategory::Port2, "Gamepad", "gamepad2");
 Asciipad asciipad2(InputCategory::Port2, "asciiPad", "asciipad2");
@@ -381,5 +487,6 @@ SuperScope superscope(InputCategory::Port2, "Super Scope", "superscope");
 Justifier justifier1(InputCategory::Port2, "Justifier 1", "justifier1");
 Justifier justifier2(InputCategory::Port2, "Justifier 2", "justifier2");
 Justifiers justifiers(justifier1, justifier2);
+
 
 }

--- a/bsnes/ui-qt/input/controller.hpp
+++ b/bsnes/ui-qt/input/controller.hpp
@@ -1,4 +1,4 @@
-struct ControllerPort1 { enum { None, Gamepad, Asciipad, Multitap, Mouse }; };
+struct ControllerPort1 { enum { None, Gamepad, Asciipad, Multitap, Mouse, NTTDataKeypad }; };
 struct ControllerPort2 { enum { None, Gamepad, Asciipad, Multitap, Mouse, SuperScope, Justifier, Justifiers }; };
 
 namespace Controllers {
@@ -59,6 +59,16 @@ struct Asciipad : InputGroup {
   Asciipad(unsigned, const char*, const char*);
 };
 
+struct NTTDataKeypad : InputGroup {
+  DigitalInput up, down, left, right, b, a, y, x, l, r, select, start;
+  DigitalInput digit0, digit1, digit2, digit3, digit4, digit5, digit6, digit7;
+  DigitalInput digit8, digit9, star, hash, period, c, hangup;
+  TurboInput turboB, turboA, turboY, turboX, turboL, turboR;
+  // TODO : Add extra buttons
+  int16_t status(unsigned, unsigned) const;
+  NTTDataKeypad(unsigned, const char*, const char*);
+};
+
 struct Mouse : InputGroup {
   AnalogInput x, y;
   DigitalInput left, right;
@@ -95,6 +105,7 @@ extern Gamepad multitap1c;
 extern Gamepad multitap1d;
 extern Multitap multitap1;
 extern Mouse mouse1;
+extern NTTDataKeypad nttdatakeypad1;
 
 extern Gamepad gamepad2;
 extern Asciipad asciipad2;

--- a/bsnes/ui-qt/utility/utility.cpp
+++ b/bsnes/ui-qt/utility/utility.cpp
@@ -119,6 +119,7 @@ void Utility::updateControllers() {
     case ControllerPort1::Asciipad: mapper().port1 = &Controllers::asciipad1; break;
     case ControllerPort1::Multitap: mapper().port1 = &Controllers::multitap1; break;
     case ControllerPort1::Mouse: mapper().port1 = &Controllers::mouse1; break;
+    case ControllerPort1::NTTDataKeypad: mapper().port1 = &Controllers::nttdatakeypad1; break;
   }
 
   switch(config().input.port2) { default:


### PR DESCRIPTION
This adds support for the NTT Data Keypad, a controller with 23 buttons normally used used with special software (eg: JRA PAT "games").

More information about this controller and the protocol is available here:
https://www.raphnet.net/divers/ntt_data_sfc_controller/index_en.php