### PR TITLE
Fixing incorrect scaling/positioning of controls in hidpi Windows env in Qt5

### DIFF
--- a/bsnes/data/bsnes.Manifest
+++ b/bsnes/data/bsnes.Manifest
@@ -8,7 +8,7 @@
   </dependency>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
When testing the Qt5/newdebugger branch on a Windows PC with a mixed-dpi multi-monitor setup (one at 100% dpi, one at 150% dpi) I noticed that the positioning and sizes of basically every UI control was broken. This change fixes it so that controls have the same sizes and positions they had in the Qt4 UI, and also the same sizing when moving windows between monitors.

Other, more modern, versions of dpiAwareness, e.g. PerMonitorV2, do not work properly, in various ways. This seems to be a systemic issue with Qt UI, as even the simplest of menu bars breaks with per-monitor dpi change notifications, and is not constrained to just this app. VLC, for example, exhibits similar issues with going between windows. (n.b., this change is actually inspired by Dolphin, which _doesn't_ exhibit these sorts of issues 😄 )

The following comparison shows the effect of this change. The first of each pair shows the application open on my hi-dpi display, and the second shows the application on my lo-dpi display. Note that between the lo and hi dpi screenshots, the only difference was simply dragging the windows from one screen to another. As well, the popup windows were not resized after being opened; they are always open to their default size.

### Before this change
<img width="895" alt="bsnes-qt5-dpi-fix-before-hi" src="https://user-images.githubusercontent.com/19677493/49300178-842f6780-f48f-11e8-9f35-f8129727db04.PNG">
<img width="598" alt="bsnes-qt5-dpi-fix-before-lo" src="https://user-images.githubusercontent.com/19677493/49300173-82fe3a80-f48f-11e8-8f64-47c42ca7a1a3.PNG">

### After this change
<img width="912" alt="bsnes-qt5-dpi-fix-after-hi" src="https://user-images.githubusercontent.com/19677493/49299829-ac6a9680-f48e-11e8-85ce-4e262f293768.PNG">
<img width="581" alt="bsnes-qt5-dpi-fix-after-lo" src="https://user-images.githubusercontent.com/19677493/49299826-aa083c80-f48e-11e8-82db-a14b830aa14d.PNG">
