### PR TITLE
Inclusion of some Qt5 binary and includes via Git Submodule to simplify Windows build 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/qt"]
+	path = external/qt
+	url = https://github.com/CypherSignal/bsnes-plus-ext-qt.git

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Non-debugging features:
 ## Building on Windows
 
 - Get mingw-w64 (http://mingw-w64.yaxm.org/doku.php/download)
-- Install Qt 4.8.6 (http://download.qt.io/archive/qt/) and make sure its `bin` directory is in your path
+- Initialize the bsnes-plus-ext-qt submodule in git
 - Run `mingw32-make`
 
 Building with the original MinGW used to be the preferred way to do it, but made building "out of the box" annoying for various reasons (including requiring outdated DirectX headers/libs and problems with some native Windows code) and is no longer supported.

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -85,7 +85,8 @@ ifeq ($(platform),osx)
 	cp -f data/bsnes.icns $(osxbundle)/Contents/Resources/AppIcon.icns
 	sed 's/@VERSION/$(version)/g' data/Info.plist > $(osxbundle)/Contents/Info.plist
 else
-	$(foreach qtdll,$(qtdlls),xcopy $(winqtpath)\bin\$(qtdll) .\out /D /Y &)
+	$(foreach qtdll,$(qtdlls),xcopy $(winqtpath)\bin\$(qtdll) .\out\ /D /Y &)
+	$(foreach qtplatformdll,$(qtplatformdlls),xcopy $(winqtpath)\$(qtplatformdll) .\out\platforms\ /D /Y &)
 	$(strip $(cpp) -o out/bsnes $(objects) $(link))
 endif
 

--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -85,6 +85,7 @@ ifeq ($(platform),osx)
 	cp -f data/bsnes.icns $(osxbundle)/Contents/Resources/AppIcon.icns
 	sed 's/@VERSION/$(version)/g' data/Info.plist > $(osxbundle)/Contents/Info.plist
 else
+	$(foreach qtdll,$(qtdlls),xcopy $(winqtpath)\bin\$(qtdll) .\out /D /Y &)
 	$(strip $(cpp) -o out/bsnes $(objects) $(link))
 endif
 

--- a/common/nall/qt/Makefile
+++ b/common/nall/qt/Makefile
@@ -9,22 +9,6 @@
 # $(qtinc) -- includes for compiling
 # $(qtlib) -- libraries for linking
 
-ifeq ($(moc),)
-  ifeq ($(qtpath),)
-    moc := moc
-  else
-    moc := $(qtpath)/bin/moc
-  endif
-endif
-
-ifeq ($(rcc),)
-  ifeq ($(qtpath),)
-    rcc := rcc
-  else
-    rcc := $(qtpath)/bin/rcc
-  endif
-endif
-
 ifeq ($(platform),$(filter $(platform),x msys))
   qtlibs := $(subst Qt,Qt5,$(qtlibs))
 
@@ -55,11 +39,8 @@ else ifeq ($(platform),osx)
   qtlib += -framework ApplicationServices
 else ifeq ($(platform),win)
   ifeq ($(qtpath),)
-    # find Qt install directory from PATH environment variable
-    qtpath := $(foreach path,$(subst ;, ,$(PATH)),$(if $(wildcard $(path)/$(moc).exe),$(path)))
-    qtpath := $(strip $(qtpath))
-    qtpath := $(subst \,/,$(qtpath))
-    qtpath := $(patsubst %/bin,%,$(qtpath))
+    qtpath := ../external/qt/mingw53_32
+    winqtpath := $(subst /,\,$(qtpath))
   endif
 
   qtinc := -I$(qtpath)/include
@@ -74,4 +55,23 @@ else ifeq ($(platform),win)
 
   # optional image-file support:
   # qtlib += -lqjpeg -lqmng
+
+  qtdlls := $(qtlibs:Qt%=Qt5%.dll)
+
+endif
+
+ifeq ($(moc),)
+  ifeq ($(qtpath),)
+    moc := moc
+  else
+    moc := $(qtpath)/bin/moc
+  endif
+endif
+
+ifeq ($(rcc),)
+  ifeq ($(qtpath),)
+    rcc := rcc
+  else
+    rcc := $(qtpath)/bin/rcc
+  endif
 endif

--- a/common/nall/qt/Makefile
+++ b/common/nall/qt/Makefile
@@ -8,6 +8,8 @@
 # $(rcc)   -- resource compiler
 # $(qtinc) -- includes for compiling
 # $(qtlib) -- libraries for linking
+# $(qtdlls) -- dlls to be copied to output directory on windows
+# $(qtplatformdlls) -- dlls to copied to "output/platforms" on windows
 
 ifeq ($(platform),$(filter $(platform),x msys))
   qtlibs := $(subst Qt,Qt5,$(qtlibs))
@@ -57,6 +59,7 @@ else ifeq ($(platform),win)
   # qtlib += -lqjpeg -lqmng
 
   qtdlls := $(qtlibs:Qt%=Qt5%.dll)
+  qtplatformdlls := plugins\platforms\qwindows.dll
 
 endif
 


### PR DESCRIPTION
[This PR fixes issue #204]

This allows for Windows developers to not have to install their own version of Qt at a system level - a rigamarole on its own, but also precludes the ability for development on multiple apps that may require conflicting versions of Qt. This was tested on a fairly clear install of Windows, with only mingw64 installed on it (no version of Qt was ever installed) and everything builds and runs fine.

An unmodified copy of binaries and code from Qt5 for building on mingw are included in a separate repo via git submodule. Only on Windows, the necessary DLLs for Qt (only) are copied into the output executable directory during make.

Long term maintenance will be updates to the external Qt repo when new versions of Qt are brought in, or if additional major components of Qt are referenced, they will have to be roped into the repo, but the makefile should seldom require updates, as it is able to reuse the QtLibs property.