### PR TITLE
New OAM Viewer

### DIFF
--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return regs.oam_basesize; 
 }
 
+unsigned PPUDebugger::oam_first_sprite() const {
+  return regs.oam_firstsprite;
+}
+
 bool PPUDebugger::mode7_extbg() const {
   return regs.mode7_extbg;
 }

--- a/bsnes/snes/alt/ppu-compatibility/debugger/debugger.hpp
+++ b/bsnes/snes/alt/ppu-compatibility/debugger/debugger.hpp
@@ -16,6 +16,7 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  unsigned  oam_first_sprite() const;
   bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
+++ b/bsnes/snes/alt/ppu-performance/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return oam.regs.base_size; 
 }
 
+unsigned PPUDebugger::oam_first_sprite() const {
+  return oam.regs.first_sprite;
+}
+
 bool PPUDebugger::mode7_extbg() const {
   return regs.mode7_extbg;
 }

--- a/bsnes/snes/alt/ppu-performance/debugger/debugger.hpp
+++ b/bsnes/snes/alt/ppu-performance/debugger/debugger.hpp
@@ -16,6 +16,7 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  unsigned  oam_first_sprite() const;
   bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/snes/ppu/debugger/debugger.cpp
+++ b/bsnes/snes/ppu/debugger/debugger.cpp
@@ -91,6 +91,10 @@ uint8 PPUDebugger::oam_base_size() const {
   return oam.regs.base_size; 
 }
 
+unsigned PPUDebugger::oam_first_sprite() const {
+  return oam.regs.first_sprite;
+}
+
 bool PPUDebugger::mode7_extbg() const {
   return regs.mode7_extbg;
 }

--- a/bsnes/snes/ppu/debugger/debugger.hpp
+++ b/bsnes/snes/ppu/debugger/debugger.hpp
@@ -16,6 +16,7 @@ public:
   uint8  bg_tile_size(unsigned index) const;
   uint16 oam_tile_addr(unsigned index) const;
   uint8  oam_base_size() const;
+  unsigned  oam_first_sprite() const;
   bool mode7_extbg() const;
   bool property(unsigned id, string &name, string &value);
 };

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -21,6 +21,8 @@ Debugger *debugger;
 #include "ppu/cgram-widget.cpp"
 #include "ppu/image-grid-widget.cpp"
 
+#include "ppu/oam-data-model.cpp"
+
 #include "ppu/tile-viewer.cpp"
 #include "ppu/tilemap-viewer.cpp"
 #include "ppu/oam-viewer.cpp"

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -22,6 +22,7 @@ Debugger *debugger;
 #include "ppu/image-grid-widget.cpp"
 
 #include "ppu/oam-data-model.cpp"
+#include "ppu/oam-graphics-scene.cpp"
 
 #include "ppu/tile-viewer.cpp"
 #include "ppu/tilemap-viewer.cpp"

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -45,6 +45,7 @@ OamDataModel::OamDataModel(QObject* parent)
 
 void OamDataModel::refresh() {
   mSizeBase = SNES::ppu.oam_base_size();
+  mFirstSprite = SNES::ppu.oam_first_sprite();
 
   for(unsigned i=0; i < N_OBJECTS; i++) {
     uint8_t d0 = SNES::memory::oam[(i << 2) + 0];

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -98,6 +98,11 @@ int OamDataModel::objectId(const QModelIndex& index) const {
   return index.row();
 }
 
+QModelIndex OamDataModel::objectIdToIndex(int id) const {
+  if(id < 0 || id >= N_OBJECTS) return QModelIndex();
+  return createIndex(id, 0);
+}
+
 bool OamDataModel::hasChildren(const QModelIndex& parent) const {
   return parent.isValid() == false;
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -1,0 +1,186 @@
+#include "oam-data-model.moc"
+
+const QStringList OamDataModel::COLUMN_STRINGS = {
+  QString::fromLatin1("#"),
+  QString::fromLatin1("Size"),
+  QString::fromLatin1("X"),
+  QString::fromLatin1("Y"),
+  QString::fromLatin1("Char"),
+  QString::fromLatin1("Pri"),
+  QString::fromLatin1("Pal"),
+  QString::fromLatin1("Flip"),
+};
+
+const QStringList OamDataModel::FLIP_STRINGS = {
+  QString::fromLatin1(""),
+  QString::fromLatin1("H"),
+  QString::fromLatin1("V"),
+  QString::fromLatin1("HV"),
+};
+
+const QVector<OamDataModel::ObjectSizes> OamDataModel::OBJECT_SIZE_TABLE = {
+  { QSize(8, 8),    QSize(16, 16),  QString::fromLatin1("8x8"),   QString::fromLatin1("16x16") },
+  { QSize(8, 8),    QSize(32, 32),  QString::fromLatin1("8x8"),   QString::fromLatin1("32x32") },
+  { QSize(8, 8),    QSize(64, 64),  QString::fromLatin1("8x8"),   QString::fromLatin1("64x64") },
+  { QSize(16, 16),  QSize(32, 32),  QString::fromLatin1("16x16"), QString::fromLatin1("32x32") },
+  { QSize(16, 16),  QSize(64, 64),  QString::fromLatin1("16x16"), QString::fromLatin1("64x64") },
+  { QSize(32, 32),  QSize(64, 64),  QString::fromLatin1("32x32"), QString::fromLatin1("64x64") },
+  { QSize(16, 32),  QSize(32, 64),  QString::fromLatin1("16x32"), QString::fromLatin1("32x64") },
+  { QSize(16, 32),  QSize(32, 32),  QString::fromLatin1("16x32"), QString::fromLatin1("32x32") },
+};
+
+OamDataModel::OamDataModel(QObject* parent)
+  : QAbstractItemModel(parent)
+  , mSizeBase(0)
+  , mOamObjects()
+{
+  assert(COLUMN_STRINGS.size() == N_COLUMNS);
+  assert(FLIP_STRINGS.size() == 4);
+  assert(OBJECT_SIZE_TABLE == N_OAM_BASE_SIZES);
+}
+
+void OamDataModel::refresh() {
+  mSizeBase = SNES::ppu.oam_base_size();
+
+  for(unsigned i=0; i < N_OBJECTS; i++) {
+    uint8_t d0 = SNES::memory::oam[(i << 2) + 0];
+    uint8_t d1 = SNES::memory::oam[(i << 2) + 1];
+    uint8_t d2 = SNES::memory::oam[(i << 2) + 2];
+    uint8_t d3 = SNES::memory::oam[(i << 2) + 3];
+    uint8_t d4 = SNES::memory::oam[512 + (i >> 2)];
+    bool x8   = d4 & (1 << ((i & 3) << 1));
+    bool size = d4 & (2 << ((i & 3) << 1));
+
+    OamObject& obj = mOamObjects[i];
+
+    obj.xpos = sclip<9>((x8 << 8) + d0);
+    obj.ypos = d1;
+    obj.character = d2;
+    obj.priority = (d3 >> 4) & 3;
+    obj.palette = (d3 >> 1) & 7;
+    obj.size = size;
+    obj.hFlip = d3 & 0x80;
+    obj.vFlip = d3 & 0x40;
+    obj.table = d3 & 0x01;
+  }
+
+  emit dataChanged(createIndex(0, 0), createIndex(N_OBJECTS-1, N_COLUMNS-1));
+}
+
+QSize OamDataModel::sizeOfObject(const OamObject& obj) const
+{
+  const ObjectSizes& sizes =  objectSizes();
+  return obj.size == false ? sizes.small : sizes.large;
+}
+
+const QString& OamDataModel::sizeStringOfObject(const OamObject& obj) const
+{
+  const ObjectSizes& sizes =  objectSizes();
+  return obj.size == false ? sizes.smallString : sizes.largeString;
+}
+
+const OamObject& OamDataModel::oamObject(const QModelIndex& index) const {
+  int id = 0;
+  if(index.model() == this && index.isValid()) id = index.row();
+
+  return mOamObjects[id % N_OBJECTS];
+}
+
+bool OamDataModel::isIndexValid(const QModelIndex& index) const {
+  return index.model() == this
+    && index.isValid()
+    && index.row() >= 0 && index.row() < N_OBJECTS
+    && index.column() >= 0 && index.column() < N_COLUMNS;
+}
+
+int OamDataModel::objectId(const QModelIndex& index) const {
+  if(isIndexValid(index) == false) return -1;
+  return index.row();
+}
+
+bool OamDataModel::hasChildren(const QModelIndex& parent) const {
+  return parent.isValid() == false;
+}
+
+int OamDataModel::rowCount(const QModelIndex& parent) const {
+  if(parent.isValid()) return 0;
+  return N_OBJECTS;
+}
+
+int OamDataModel::columnCount(const QModelIndex& parent) const {
+  if(parent.isValid()) return 0;
+  return N_COLUMNS;
+}
+
+QModelIndex OamDataModel::index(int row, int column, const QModelIndex& parent) const {
+  if(parent.isValid()
+     || row < 0 || row >= N_OBJECTS
+     || column < 0 || column >= N_COLUMNS) {
+
+    return QModelIndex();
+  }
+
+  return createIndex(row, column);
+}
+
+QModelIndex OamDataModel::parent(const QModelIndex & index) const {
+  return QModelIndex();
+}
+
+QVariant OamDataModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  if(orientation != Qt::Horizontal
+    || section < 0 || section >= N_COLUMNS
+    || role != Qt::DisplayRole) {
+
+    return QVariant();
+  }
+
+  return COLUMN_STRINGS.at(section);
+}
+
+QVariant OamDataModel::data(const QModelIndex& index, int role) const {
+  if(isIndexValid(index) == false) return QVariant();
+
+  if(role == Qt::DisplayRole) {
+    const OamObject& obj = oamObject(index.row());
+
+    switch(static_cast<Columns>(index.column())) {
+      case ID:        return index.row();
+      case SIZE:      return sizeStringOfObject(obj);
+      case XPOS:      return obj.xpos;
+      case YPOS:      return obj.ypos;
+      case CHAR:      return obj.character + (obj.table << 8);
+      case PRIORITY:  return obj.priority;
+      case PALETTE:   return obj.palette;
+      case FLIP:      return FLIP_STRINGS.at(obj.hFlip | (obj.vFlip << 1));
+    }
+  }
+  else if(role == SortRole) {
+    const OamObject& obj = oamObject(index.row());
+    switch(static_cast<Columns>(index.column())) {
+      case ID:        return index.row();
+      case SIZE:      return obj.size;
+      case XPOS:      return obj.xpos;
+      case YPOS:      return obj.ypos;
+      case CHAR:      return obj.character + (obj.table << 8);
+      case PRIORITY:  return obj.priority;
+      case PALETTE:   return obj.palette;
+      case FLIP:      return obj.hFlip | (obj.vFlip << 1);
+    }
+  }
+  else if(role == Qt::TextAlignmentRole) {
+    switch(static_cast<Columns>(index.column())) {
+      case ID:        return Qt::AlignRight;
+      case SIZE:      return Qt::AlignHCenter;
+      case XPOS:      return Qt::AlignRight;
+      case YPOS:      return Qt::AlignRight;
+      case CHAR:      return Qt::AlignRight;
+      case PRIORITY:  return Qt::AlignRight;
+      case PALETTE:   return Qt::AlignRight;
+      case FLIP:      return Qt::AlignLeft;
+    }
+  }
+
+  return QVariant();
+}
+

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -59,8 +59,8 @@ void OamDataModel::refresh() {
     obj.priority = (d3 >> 4) & 3;
     obj.palette = (d3 >> 1) & 7;
     obj.size = size;
-    obj.hFlip = d3 & 0x80;
-    obj.vFlip = d3 & 0x40;
+    obj.vFlip = d3 & 0x80;
+    obj.hFlip = d3 & 0x40;
     obj.table = d3 & 0x01;
   }
 

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -19,14 +19,14 @@ const QStringList OamDataModel::FLIP_STRINGS = {
 };
 
 const QVector<OamDataModel::ObjectSizes> OamDataModel::OBJECT_SIZE_TABLE = {
-  { QSize(8, 8),    QSize(16, 16),  QString::fromLatin1("8x8"),   QString::fromLatin1("16x16") },
-  { QSize(8, 8),    QSize(32, 32),  QString::fromLatin1("8x8"),   QString::fromLatin1("32x32") },
-  { QSize(8, 8),    QSize(64, 64),  QString::fromLatin1("8x8"),   QString::fromLatin1("64x64") },
-  { QSize(16, 16),  QSize(32, 32),  QString::fromLatin1("16x16"), QString::fromLatin1("32x32") },
-  { QSize(16, 16),  QSize(64, 64),  QString::fromLatin1("16x16"), QString::fromLatin1("64x64") },
-  { QSize(32, 32),  QSize(64, 64),  QString::fromLatin1("32x32"), QString::fromLatin1("64x64") },
-  { QSize(16, 32),  QSize(32, 64),  QString::fromLatin1("16x32"), QString::fromLatin1("32x64") },
-  { QSize(16, 32),  QSize(32, 32),  QString::fromLatin1("16x32"), QString::fromLatin1("32x32") },
+  { QSize(8, 8),    QSize(16, 16),  QString::fromLatin1("8x8"),   QString::fromLatin1("16x16"), 16 },
+  { QSize(8, 8),    QSize(32, 32),  QString::fromLatin1("8x8"),   QString::fromLatin1("32x32"), 32 },
+  { QSize(8, 8),    QSize(64, 64),  QString::fromLatin1("8x8"),   QString::fromLatin1("64x64"), 64 },
+  { QSize(16, 16),  QSize(32, 32),  QString::fromLatin1("16x16"), QString::fromLatin1("32x32"), 32 },
+  { QSize(16, 16),  QSize(64, 64),  QString::fromLatin1("16x16"), QString::fromLatin1("64x64"), 64 },
+  { QSize(32, 32),  QSize(64, 64),  QString::fromLatin1("32x32"), QString::fromLatin1("64x64"), 64 },
+  { QSize(16, 32),  QSize(32, 64),  QString::fromLatin1("16x32"), QString::fromLatin1("32x64"), 64 },
+  { QSize(16, 32),  QSize(32, 32),  QString::fromLatin1("16x32"), QString::fromLatin1("32x32"), 32 },
 };
 
 OamDataModel::OamDataModel(QObject* parent)

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -1,0 +1,76 @@
+
+struct OamObject {
+  signed   xpos;
+  unsigned ypos;
+  unsigned character;
+  unsigned priority;
+  unsigned palette;
+  bool size;
+  bool hFlip;
+  bool vFlip;
+  bool table;
+};
+
+class OamDataModel : public QAbstractItemModel {
+  Q_OBJECT
+
+public:
+  static const int N_OBJECTS = 128;
+
+  enum Columns {
+    ID,
+    SIZE,
+    XPOS,
+    YPOS,
+    CHAR,
+    PRIORITY,
+    PALETTE,
+    FLIP,
+  };
+  static const int N_COLUMNS = 8;
+  static const QStringList COLUMN_STRINGS;
+  static const QStringList FLIP_STRINGS;
+
+  struct ObjectSizes {
+    const QSize small;
+    const QSize large;
+    const QString smallString;
+    const QString largeString;
+  };
+  static const int N_OAM_BASE_SIZES = 8;
+  static const QVector<ObjectSizes> OBJECT_SIZE_TABLE;
+
+  static const int SortRole = Qt::UserRole + 1;
+
+private:
+  unsigned mSizeBase;
+  OamObject mOamObjects[N_OBJECTS];
+
+public:
+  OamDataModel(QObject* parent);
+
+  void refresh();
+
+  const ObjectSizes& objectSizes() const { return OBJECT_SIZE_TABLE.at(mSizeBase % N_OAM_BASE_SIZES); }
+  QSize sizeOfObject(const OamObject& obj) const;
+  const QString& sizeStringOfObject(const OamObject& obj) const;
+
+  const OamObject& oamObject(unsigned id) const { return mOamObjects[id % N_OBJECTS]; }
+  const OamObject& oamObject(const QModelIndex& index) const;
+
+  bool isIndexValid(const QModelIndex& index) const;
+
+  // returns -1 if the index is invalid
+  int objectId(const QModelIndex& index) const;
+
+  virtual bool hasChildren(const QModelIndex& parent) const override;
+  virtual int rowCount(const QModelIndex& parent) const override;
+  virtual int columnCount(const QModelIndex& parent) const override;
+
+  virtual QModelIndex index(int row, int column, const QModelIndex& parent) const override;
+  virtual QModelIndex parent(const QModelIndex & index) const override;
+
+  virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+  virtual QVariant data(const QModelIndex& index, int role) const override;
+};
+

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -9,6 +9,8 @@ struct OamObject {
   bool hFlip;
   bool vFlip;
   bool table;
+
+  bool visible;
 };
 
 class OamDataModel : public QAbstractItemModel {
@@ -73,7 +75,19 @@ public:
   virtual QModelIndex index(int row, int column, const QModelIndex& parent) const override;
   virtual QModelIndex parent(const QModelIndex & index) const override;
 
+  virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
+
   virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
   virtual QVariant data(const QModelIndex& index, int role) const override;
+  virtual bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
+  void toggleVisibility(const QSet<int>& objectIds);
+  void showOnlySelectedObjects(const QSet<int>& objectIds);
+
+public slots:
+  void showAllObjects();
+
+signals:
+  void visibilityChanged();
 };
 

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -47,6 +47,7 @@ public:
 
 private:
   unsigned mSizeBase;
+  unsigned mFirstSprite;
   OamObject mOamObjects[N_OBJECTS];
 
 public:
@@ -57,6 +58,8 @@ public:
   const ObjectSizes& objectSizes() const { return OBJECT_SIZE_TABLE.at(mSizeBase % N_OAM_BASE_SIZES); }
   QSize sizeOfObject(const OamObject& obj) const;
   const QString& sizeStringOfObject(const OamObject& obj) const;
+
+  unsigned firstSprite() const { return mFirstSprite; }
 
   const OamObject& oamObject(unsigned id) const { return mOamObjects[id % N_OBJECTS]; }
   const OamObject& oamObject(const QModelIndex& index) const;

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -36,6 +36,7 @@ public:
     const QSize large;
     const QString smallString;
     const QString largeString;
+    const unsigned maximumSize;
   };
   static const int N_OAM_BASE_SIZES = 8;
   static const QVector<ObjectSizes> OBJECT_SIZE_TABLE;

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -64,6 +64,8 @@ public:
   // returns -1 if the index is invalid
   int objectId(const QModelIndex& index) const;
 
+  QModelIndex objectIdToIndex(int id) const;
+
   virtual bool hasChildren(const QModelIndex& parent) const override;
   virtual int rowCount(const QModelIndex& parent) const override;
   virtual int columnCount(const QModelIndex& parent) const override;

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -203,8 +203,7 @@ void OamGraphicsScene::refresh() {
   this->setSceneRect(bRect);
   backgroundRectItem->setRect(bRect);
 
-  // ::TODO get screen height::
-  const int screenHeight = 224;
+  const int screenHeight = SNES::ppu.overscan() == false ? 224 : 239;
   screenOutlineRectItem->setRect(0, 0, 256, screenHeight);
 
   refreshRectItemColors();

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -7,7 +7,7 @@ OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
   , largeImageBuffer()
   , spritePalette()
   , objects()
-  , backgroundType(BackgroundType::BG_TRANSPARENT)
+  , backgroundType(BackgroundType::TRANSPARENT_BG)
   , showScreenOutline(true)
 {
   const QString toolTipStr = QString::fromLatin1("Sprite %1");
@@ -117,7 +117,7 @@ QImage OamGraphicsScene::renderToImage() {
 
   clearSelection();
 
-  QImage::Format format = backgroundType == BackgroundType::BG_TRANSPARENT ? QImage::Format_ARGB32 : QImage::Format_RGB32;
+  QImage::Format format = backgroundType == BackgroundType::TRANSPARENT_BG ? QImage::Format_ARGB32 : QImage::Format_RGB32;
 
   QImage image(sceneRect().size().toSize(), format);
   image.fill(0);
@@ -214,7 +214,7 @@ void OamGraphicsScene::refresh() {
 
 void OamGraphicsScene::refreshRectItemColors()
 {
-  if(backgroundType == BackgroundType::BG_TRANSPARENT) {
+  if(backgroundType == BackgroundType::TRANSPARENT_BG) {
     backgroundRectItem->setBrush(Qt::NoBrush);
     screenOutlineRectItem->setPen(QPen(Qt::black, 0));
     return;

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -10,15 +10,17 @@ OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
 {
   const QString toolTipStr = QString::fromLatin1("Sprite %1");
 
-  objects.reserve(N_OBJECTS);
+  objects.reserve(N_OBJECTS * 2);
 
-  for(int i = 0; i < N_OBJECTS; i++) {
+  for(int i = 0; i < N_OBJECTS * 2; i++) {
+    int objectId = i % N_OBJECTS;
+
     QGraphicsPixmapItem* item = new QGraphicsPixmapItem;
 
-    item->setData(IdRole, i);
-    item->setToolTip(toolTipStr.arg(i));
+    item->setData(IdRole, objectId);
+    item->setToolTip(toolTipStr.arg(objectId));
 
-    item->setZValue(N_OBJECTS - i);
+    item->setZValue(N_OBJECTS - objectId);
 
     this->addItem(item);
 
@@ -59,6 +61,18 @@ void OamGraphicsScene::refresh() {
     else {
       drawObject(largeImageBuffer, obj);
       item->setPixmap(QPixmap::fromImage(largeImageBuffer));
+    }
+
+    QGraphicsPixmapItem* yWrapedItem = objects.at(N_OBJECTS + id);
+    const QSize objSize = dataModel->sizeOfObject(obj);
+    if(obj.ypos + objSize.height() > 256) {
+        yWrapedItem->setPixmap(item->pixmap());
+        yWrapedItem->setPos(obj.xpos, int(obj.ypos) - 256);
+        yWrapedItem->setVisible(true);
+    }
+    else {
+        yWrapedItem->setPixmap(QPixmap());
+        yWrapedItem->setVisible(false);
     }
   }
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -25,8 +25,6 @@ OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
     item->setFlag(QGraphicsItem::ItemIsSelectable, true);
     item->setShapeMode(QGraphicsPixmapItem::BoundingRectShape);
 
-    item->setZValue(N_OBJECTS - objectId);
-
     this->addItem(item);
 
     objects.append(item);
@@ -163,6 +161,7 @@ void OamGraphicsScene::refresh() {
   updateBackgroundColors();
 
   const OamDataModel::ObjectSizes& objectSizes = dataModel->objectSizes();
+  const unsigned firstSprite = dataModel->firstSprite();
 
   resizeImageBuffer(smallImageBuffer, objectSizes.small);
   resizeImageBuffer(largeImageBuffer, objectSizes.large);
@@ -171,7 +170,10 @@ void OamGraphicsScene::refresh() {
     QGraphicsPixmapItem* item = objects.at(id);
     const OamObject& obj = dataModel->oamObject(id);
 
+    int zValue = N_OBJECTS - ((id + N_OBJECTS - firstSprite) % N_OBJECTS) + 100;
+
     item->setPos(obj.xpos, obj.ypos);
+    item->setZValue(zValue);
 
     if(obj.size == false) {
       drawObject(smallImageBuffer, obj);
@@ -187,6 +189,7 @@ void OamGraphicsScene::refresh() {
     if(obj.ypos + objSize.height() > 256) {
         yWrapedItem->setPixmap(item->pixmap());
         yWrapedItem->setPos(obj.xpos, int(obj.ypos) - 256);
+        yWrapedItem->setZValue(zValue);
         yWrapedItem->setVisible(obj.visible);
         yWrapedItem->setSelected(selectedIds_.contains(id));
     }

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -1,0 +1,127 @@
+#include "oam-graphics-scene.moc"
+
+OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
+  : QGraphicsScene(parent)
+  , dataModel(dataModel)
+  , smallImageBuffer()
+  , largeImageBuffer()
+  , spritePalette()
+  , objects()
+{
+  const QString toolTipStr = QString::fromLatin1("Sprite %1");
+
+  objects.reserve(N_OBJECTS);
+
+  for(int i = 0; i < N_OBJECTS; i++) {
+    QGraphicsPixmapItem* item = new QGraphicsPixmapItem;
+
+    item->setData(IdRole, i);
+    item->setToolTip(toolTipStr.arg(i));
+
+    item->setZValue(N_OBJECTS - i);
+
+    this->addItem(item);
+
+    objects.append(item);
+  }
+}
+
+QRgb OamGraphicsScene::backgroundColorForObject(int id) {
+  if(id < 0 || id >= N_OBJECTS) return qRgba(0, 0, 0, 0);
+
+  const OamObject& obj = dataModel->oamObject(id);
+  return backgroundColors[obj.palette % N_PALETTES];
+}
+
+QPixmap OamGraphicsScene::pixmapForObject(int id) {
+  if(id < 0 || id >= N_OBJECTS) return QPixmap();
+
+  return objects.at(id)->pixmap();
+}
+
+void OamGraphicsScene::refresh() {
+  updateSpritePalette();
+  updateBackgroundColors();
+
+  resizeImageBuffer(smallImageBuffer, dataModel->objectSizes().small);
+  resizeImageBuffer(largeImageBuffer, dataModel->objectSizes().large);
+
+  for(int id = 0; id < N_OBJECTS; id++) {
+    QGraphicsPixmapItem* item = objects.at(id);
+    const OamObject& obj = dataModel->oamObject(id);
+
+    item->setPos(obj.xpos, obj.ypos);
+
+    if(obj.size == false) {
+      drawObject(smallImageBuffer, obj);
+      item->setPixmap(QPixmap::fromImage(smallImageBuffer));
+    }
+    else {
+      drawObject(largeImageBuffer, obj);
+      item->setPixmap(QPixmap::fromImage(largeImageBuffer));
+    }
+  }
+}
+
+void OamGraphicsScene::updateSpritePalette() {
+  for(int p = 0; p < N_PALETTES; p++) {
+    for(int c = 1; c < 16; c++) {
+      spritePalette[p * 16 + c] = rgbFromCgram(128 + p * 16 + c);
+    }
+    spritePalette[p * 16] = qRgba(0, 0, 0, 0);
+  }
+}
+
+void OamGraphicsScene::updateBackgroundColors() {
+  for(int p = 0; p < N_PALETTES; p++) {
+    backgroundColors[p] = rgbFromCgram(128 + p * 16);
+  }
+}
+
+void OamGraphicsScene::resizeImageBuffer(QImage& imageBuffer, const QSize& size) {
+  if(imageBuffer.size() != size) {
+    QImage newImage(size, QImage::Format_ARGB32);
+    imageBuffer.swap(newImage);
+  }
+}
+
+void OamGraphicsScene::drawObject(QImage& buffer, const OamObject& obj) {
+  // assumes buffer is the same size as the object
+
+  const QSize objSize = dataModel->sizeOfObject(obj);
+
+  const QRgb* pal = spritePalette + (obj.palette % N_PALETTES) * 16;
+  const uint8_t *objTileset = SNES::memory::vram.data() + SNES::ppu.oam_tile_addr(obj.table);
+
+  for(unsigned ty = 0; ty < objSize.height() / 8; ty++) {
+    for(unsigned tx = 0; tx < objSize.width() / 8; tx++) {
+      const unsigned cx = (obj.character + tx) & 0x00f;
+      const unsigned cy = (obj.character / 16) + ty;
+      const uint8_t* tile = objTileset + cy * 512 + cx * 32;
+
+      for(unsigned py = 0; py < 8; py++) {
+        const unsigned iy = ty * 8 + py;
+        const unsigned fiy = (obj.vFlip == false) ? iy : objSize.height() - iy - 1;
+
+        QRgb* dest = (QRgb*)buffer.scanLine(fiy);
+
+        uint8_t d0 = tile[ 0];
+        uint8_t d1 = tile[ 1];
+        uint8_t d2 = tile[16];
+        uint8_t d3 = tile[17];
+        for(unsigned px = 0; px < 8; px++) {
+          const unsigned ix = tx * 8 + px;
+          const unsigned fix = obj.hFlip == false ? ix : objSize.width() - ix - 1;
+
+          uint8_t pixel = 0;
+          pixel |= (d0 & (0x80 >> px)) ? 1 : 0;
+          pixel |= (d1 & (0x80 >> px)) ? 2 : 0;
+          pixel |= (d2 & (0x80 >> px)) ? 4 : 0;
+          pixel |= (d3 & (0x80 >> px)) ? 8 : 0;
+          dest[fix] = pal[pixel];
+        }
+        tile += 2;
+      }
+    }
+  }
+}

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -43,6 +43,18 @@ OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
   refreshRectItemColors();
 }
 
+QImage OamGraphicsScene::renderToImage() {
+  QImage::Format format = backgroundType == BackgroundType::TRANSPARENT ? QImage::Format_ARGB32 : QImage::Format_RGB32;
+
+  QImage image(sceneRect().size().toSize(), format);
+  image.fill(0);
+
+  QPainter painter(&image);
+  render(&painter);
+
+  return image;
+}
+
 void OamGraphicsScene::setBackrgoundType(BackgroundType type) {
   if(backgroundType != type) {
     backgroundType = type;

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.cpp
@@ -7,7 +7,7 @@ OamGraphicsScene::OamGraphicsScene(OamDataModel* dataModel, QObject* parent)
   , largeImageBuffer()
   , spritePalette()
   , objects()
-  , backgroundType(BackgroundType::TRANSPARENT)
+  , backgroundType(BackgroundType::BG_TRANSPARENT)
   , showScreenOutline(true)
 {
   const QString toolTipStr = QString::fromLatin1("Sprite %1");
@@ -117,7 +117,7 @@ QImage OamGraphicsScene::renderToImage() {
 
   clearSelection();
 
-  QImage::Format format = backgroundType == BackgroundType::TRANSPARENT ? QImage::Format_ARGB32 : QImage::Format_RGB32;
+  QImage::Format format = backgroundType == BackgroundType::BG_TRANSPARENT ? QImage::Format_ARGB32 : QImage::Format_RGB32;
 
   QImage image(sceneRect().size().toSize(), format);
   image.fill(0);
@@ -214,7 +214,7 @@ void OamGraphicsScene::refresh() {
 
 void OamGraphicsScene::refreshRectItemColors()
 {
-  if(backgroundType == BackgroundType::TRANSPARENT) {
+  if(backgroundType == BackgroundType::BG_TRANSPARENT) {
     backgroundRectItem->setBrush(Qt::NoBrush);
     screenOutlineRectItem->setPen(QPen(Qt::black, 0));
     return;

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -53,6 +53,8 @@ public:
   QRgb backgroundColorForObject(int id);
   QPixmap pixmapForObject(int id);
 
+  QImage renderToImage();
+
   void setBackrgoundType(BackgroundType type);
 
 public slots:

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -1,0 +1,38 @@
+
+class OamGraphicsScene : public QGraphicsScene {
+  Q_OBJECT
+
+public:
+  static const int N_OBJECTS = 128;
+  static const int N_PALETTES = 8;
+
+  static const int IdRole = 0;
+
+private:
+  OamDataModel* dataModel;
+
+  QImage smallImageBuffer;
+  QImage largeImageBuffer;
+
+  // NOTE: the first color for every palette is transparent.
+  QRgb spritePalette[N_PALETTES * 16];
+  QRgb backgroundColors[N_PALETTES];
+
+  QList<QGraphicsPixmapItem*> objects;
+
+public:
+  OamGraphicsScene(OamDataModel* dataModel, QObject* parent);
+
+  QRgb backgroundColorForObject(int id);
+  QPixmap pixmapForObject(int id);
+
+  void refresh();
+
+private:
+  void updateSpritePalette();
+  void updateBackgroundColors();
+  void resizeImageBuffer(QImage& imageBuffer, const QSize& size);
+
+  void drawObject(QImage& buffer, const OamObject& obj);
+};
+

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -9,7 +9,7 @@ public:
   static const int IdRole = 0;
 
   enum BackgroundType {
-    BG_TRANSPARENT,
+    TRANSPARENT_BG,
     SCREEN_BG,
     PALETTE_0_BG,
     PALETTE_1_BG,

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -43,12 +43,18 @@ private:
   QGraphicsRectItem* backgroundRectItem;
   QGraphicsRectItem* screenOutlineRectItem;
 
+  QSet<int> selectedIds_;
+
   BackgroundType backgroundType;
   bool showScreenOutline;
 
 
 public:
   OamGraphicsScene(OamDataModel* dataModel, QObject* parent);
+
+  // setSelectedId DOES NOT emit selectedIdsEdited
+  void setSelectedIds(const QSet<int>& selectedIds);
+  const QSet<int>& selectedIds() const { return selectedIds_; }
 
   QRgb backgroundColorForObject(int id);
   QPixmap pixmapForObject(int id);
@@ -57,12 +63,20 @@ public:
 
   void setBackrgoundType(BackgroundType type);
 
+signals:
+  // emitted when the user selects an object manually
+  void selectedIdsEdited();
+
 public slots:
+  void onSelectionChanged();
+
   void setShowScreenOutline(bool s);
 
   void refresh();
 
 private:
+  void updateSelectedItems();
+
   void refreshRectItemColors();
 
   void updateSpritePalette();

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -18,6 +18,8 @@ private:
   QRgb spritePalette[N_PALETTES * 16];
   QRgb backgroundColors[N_PALETTES];
 
+  // items 0 - 127 are the main objects (always shown)
+  // items 128 - 255 are the Y axis wrapped objects (sometimes shown)
   QList<QGraphicsPixmapItem*> objects;
 
 public:

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -9,7 +9,7 @@ public:
   static const int IdRole = 0;
 
   enum BackgroundType {
-    TRANSPARENT,
+    BG_TRANSPARENT,
     SCREEN_BG,
     PALETTE_0_BG,
     PALETTE_1_BG,

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -63,12 +63,16 @@ public:
 
   void setBackrgoundType(BackgroundType type);
 
+protected:
+  virtual void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+
 signals:
   // emitted when the user selects an object manually
   void selectedIdsEdited();
 
 public slots:
   void onSelectionChanged();
+  void onModelVisibilityChanged();
 
   void setShowScreenOutline(bool s);
 

--- a/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-graphics-scene.moc.hpp
@@ -8,6 +8,23 @@ public:
 
   static const int IdRole = 0;
 
+  enum BackgroundType {
+    TRANSPARENT,
+    SCREEN_BG,
+    PALETTE_0_BG,
+    PALETTE_1_BG,
+    PALETTE_2_BG,
+    PALETTE_3_BG,
+    PALETTE_4_BG,
+    PALETTE_5_BG,
+    PALETTE_6_BG,
+    PALETTE_7_BG,
+    MAGENTA,
+    CYAN,
+    WHITE,
+    BLACK,
+  };
+
 private:
   OamDataModel* dataModel;
 
@@ -17,10 +34,18 @@ private:
   // NOTE: the first color for every palette is transparent.
   QRgb spritePalette[N_PALETTES * 16];
   QRgb backgroundColors[N_PALETTES];
+  QRgb screenBackgroundColor;
 
   // items 0 - 127 are the main objects (always shown)
   // items 128 - 255 are the Y axis wrapped objects (sometimes shown)
   QList<QGraphicsPixmapItem*> objects;
+
+  QGraphicsRectItem* backgroundRectItem;
+  QGraphicsRectItem* screenOutlineRectItem;
+
+  BackgroundType backgroundType;
+  bool showScreenOutline;
+
 
 public:
   OamGraphicsScene(OamDataModel* dataModel, QObject* parent);
@@ -28,13 +53,20 @@ public:
   QRgb backgroundColorForObject(int id);
   QPixmap pixmapForObject(int id);
 
+  void setBackrgoundType(BackgroundType type);
+
+public slots:
+  void setShowScreenOutline(bool s);
+
   void refresh();
 
 private:
+  void refreshRectItemColors();
+
   void updateSpritePalette();
   void updateBackgroundColors();
-  void resizeImageBuffer(QImage& imageBuffer, const QSize& size);
 
+  void resizeImageBuffer(QImage& imageBuffer, const QSize& size);
   void drawObject(QImage& buffer, const OamObject& obj);
 };
 

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -174,8 +174,8 @@ void OamCanvas::refreshImage(const OamObject& obj) {
   }
 
   int zoom = imageSize / maximumOamBaseSize();
-  int xScale = obj.vFlip ? -zoom : zoom;
-  int yScale = obj.hFlip ? -zoom : zoom;
+  int xScale = obj.hFlip ? -zoom : zoom;
+  int yScale = obj.vFlip ? -zoom : zoom;
 
   image = buffer.transformed(QTransform::fromScale(xScale, yScale), Qt::FastTransformation);
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -63,27 +63,47 @@ OamViewer::OamViewer() {
   treeView->sortByColumn(OamDataModel::Columns::ID, Qt::AscendingOrder);
 
 
-  controlLayout = new QVBoxLayout;
-  controlLayout->setAlignment(Qt::AlignTop);
-  controlLayout->setSpacing(0);
-  layout->addLayout(controlLayout);
-
+  sidebarLayout = new QFormLayout;
+  sidebarLayout->setSizeConstraint(QLayout::SetMinimumSize);
+  sidebarLayout->setRowWrapPolicy(QFormLayout::DontWrapRows);
+  sidebarLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+  sidebarLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
+  sidebarLayout->setLabelAlignment(Qt::AlignLeft);
+  layout->addLayout(sidebarLayout);
 
   canvas = new OamCanvas(dataModel, graphicsScene, this);
-  controlLayout->addWidget(canvas);
+  sidebarLayout->addRow(canvas);
+
+  zoomCombo = new QComboBox;
+  zoomCombo->addItem("1x", QVariant(1));
+  zoomCombo->addItem("2x", QVariant(2));
+  zoomCombo->addItem("3x", QVariant(3));
+  zoomCombo->addItem("4x", QVariant(4));
+  zoomCombo->addItem("5x", QVariant(5));
+  zoomCombo->addItem("6x", QVariant(6));
+  zoomCombo->addItem("7x", QVariant(7));
+  zoomCombo->addItem("8x", QVariant(8));
+  zoomCombo->addItem("9x", QVariant(9));
+  sidebarLayout->addRow("Zoom:", zoomCombo);
 
   autoUpdateBox = new QCheckBox("Auto update");
-  controlLayout->addWidget(autoUpdateBox);
+  sidebarLayout->addRow(autoUpdateBox);
 
   refreshButton = new QPushButton("Refresh");
-  controlLayout->addWidget(refreshButton);
+  sidebarLayout->addRow(refreshButton);
+
 
   splitter->setSizes({ INT_MAX / 100 * 2, INT_MAX / 100 * 1 });
   splitter->setStretchFactor(0, 2);
   splitter->setStretchFactor(1, 1);
 
 
+  zoomCombo->setCurrentIndex(0);
+  onZoomChanged(0);
+
+
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
+  connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
   connect(treeView->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&,const QItemSelection&)), this, SLOT(onSelectionChanged()));
 }
 
@@ -106,6 +126,12 @@ void OamViewer::refresh() {
   canvas->refresh();
 
   inRefreshCall = false;
+}
+
+void OamViewer::onZoomChanged(int index)
+{
+  unsigned z = zoomCombo->itemData(index).toUInt();
+  graphicsView->setTransform(QTransform::fromScale(z, z));
 }
 
 void OamViewer::onSelectionChanged() {

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -89,8 +89,17 @@ OamViewer::OamViewer() {
   autoUpdateBox = new QCheckBox("Auto update");
   sidebarLayout->addRow(autoUpdateBox);
 
+
+  buttonLayout = new QHBoxLayout;
+
+  exportButton = new QPushButton("Export");
+  buttonLayout->addWidget(exportButton);
+
   refreshButton = new QPushButton("Refresh");
-  sidebarLayout->addRow(refreshButton);
+  buttonLayout->addWidget(refreshButton);
+
+  sidebarLayout->addRow(buttonLayout);
+
 
   showScreenOutlineBox = new QCheckBox("Show Screen Outline");
   showScreenOutlineBox->setChecked(true);
@@ -123,6 +132,7 @@ OamViewer::OamViewer() {
   onZoomChanged(0);
 
 
+  connect(exportButton,  SIGNAL(clicked()),  this, SLOT(onExportClicked()));
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
   connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
   connect(showScreenOutlineBox, SIGNAL(clicked(bool)), graphicsScene, SLOT(setShowScreenOutline(bool)));
@@ -149,6 +159,23 @@ void OamViewer::refresh() {
   canvas->refresh();
 
   inRefreshCall = false;
+}
+
+void OamViewer::onExportClicked() {
+  QImage image = graphicsScene->renderToImage();
+
+  if(image.isNull()) return;
+
+  QString selectedFile = QFileDialog::getSaveFileName(
+    this, "Export Sprites", config().path.current.exportVRAM, "PNG Image (*.png)");
+
+  if(!selectedFile.isEmpty()) {
+    QImageWriter writer(selectedFile, "PNG");
+    if(!writer.write(image)) {
+      QMessageBox::critical(this, "Export Sprites", "Unable to export sprites:\n\n" + writer.errorString());
+    }
+    config().path.current.exportVRAM = selectedFile;
+  }
 }
 
 void OamViewer::onZoomChanged(int index)

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -110,7 +110,7 @@ OamViewer::OamViewer() {
   sidebarLayout->addRow(showScreenOutlineBox);
 
   backgroundCombo = new QComboBox;
-  backgroundCombo->addItem("Transparent",      OamGraphicsScene::BackgroundType::BG_TRANSPARENT);
+  backgroundCombo->addItem("Transparent",      OamGraphicsScene::BackgroundType::TRANSPARENT_BG);
   backgroundCombo->addItem("Screen BG",        OamGraphicsScene::BackgroundType::SCREEN_BG);
   backgroundCombo->addItem("Sprite Palette 0", OamGraphicsScene::BackgroundType::PALETTE_0_BG);
   backgroundCombo->addItem("Sprite Palette 1", OamGraphicsScene::BackgroundType::PALETTE_1_BG);

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -92,6 +92,27 @@ OamViewer::OamViewer() {
   refreshButton = new QPushButton("Refresh");
   sidebarLayout->addRow(refreshButton);
 
+  showScreenOutlineBox = new QCheckBox("Show Screen Outline");
+  showScreenOutlineBox->setChecked(true);
+  sidebarLayout->addRow(showScreenOutlineBox);
+
+  backgroundCombo = new QComboBox;
+  backgroundCombo->addItem("Transparent",      OamGraphicsScene::BackgroundType::TRANSPARENT);
+  backgroundCombo->addItem("Screen BG",        OamGraphicsScene::BackgroundType::SCREEN_BG);
+  backgroundCombo->addItem("Sprite Palette 0", OamGraphicsScene::BackgroundType::PALETTE_0_BG);
+  backgroundCombo->addItem("Sprite Palette 1", OamGraphicsScene::BackgroundType::PALETTE_1_BG);
+  backgroundCombo->addItem("Sprite Palette 2", OamGraphicsScene::BackgroundType::PALETTE_2_BG);
+  backgroundCombo->addItem("Sprite Palette 3", OamGraphicsScene::BackgroundType::PALETTE_3_BG);
+  backgroundCombo->addItem("Sprite Palette 4", OamGraphicsScene::BackgroundType::PALETTE_4_BG);
+  backgroundCombo->addItem("Sprite Palette 5", OamGraphicsScene::BackgroundType::PALETTE_5_BG);
+  backgroundCombo->addItem("Sprite Palette 6", OamGraphicsScene::BackgroundType::PALETTE_6_BG);
+  backgroundCombo->addItem("Sprite Palette 7", OamGraphicsScene::BackgroundType::PALETTE_7_BG);
+  backgroundCombo->addItem("Magenta",          OamGraphicsScene::BackgroundType::MAGENTA);
+  backgroundCombo->addItem("Cyan",             OamGraphicsScene::BackgroundType::CYAN);
+  backgroundCombo->addItem("White",            OamGraphicsScene::BackgroundType::WHITE);
+  backgroundCombo->addItem("Black",            OamGraphicsScene::BackgroundType::BLACK);
+  sidebarLayout->addRow("Background:", backgroundCombo);
+
 
   splitter->setSizes({ INT_MAX / 100 * 2, INT_MAX / 100 * 1 });
   splitter->setStretchFactor(0, 2);
@@ -104,6 +125,8 @@ OamViewer::OamViewer() {
 
   connect(refreshButton, SIGNAL(released()), this, SLOT(refresh()));
   connect(zoomCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onZoomChanged(int)));
+  connect(showScreenOutlineBox, SIGNAL(clicked(bool)), graphicsScene, SLOT(setShowScreenOutline(bool)));
+  connect(backgroundCombo,     SIGNAL(currentIndexChanged(int)), this, SLOT(onBackgroundChanged(int)));
   connect(treeView->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&,const QItemSelection&)), this, SLOT(onSelectionChanged()));
 }
 
@@ -132,6 +155,12 @@ void OamViewer::onZoomChanged(int index)
 {
   unsigned z = zoomCombo->itemData(index).toUInt();
   graphicsView->setTransform(QTransform::fromScale(z, z));
+}
+
+void OamViewer::onBackgroundChanged(int index)
+{
+  int t = backgroundCombo->itemData(index).toInt();
+  graphicsScene->setBackrgoundType(static_cast<OamGraphicsScene::BackgroundType>(t));
 }
 
 void OamViewer::onSelectionChanged() {

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -110,7 +110,7 @@ OamViewer::OamViewer() {
   sidebarLayout->addRow(showScreenOutlineBox);
 
   backgroundCombo = new QComboBox;
-  backgroundCombo->addItem("Transparent",      OamGraphicsScene::BackgroundType::TRANSPARENT);
+  backgroundCombo->addItem("Transparent",      OamGraphicsScene::BackgroundType::BG_TRANSPARENT);
   backgroundCombo->addItem("Screen BG",        OamGraphicsScene::BackgroundType::SCREEN_BG);
   backgroundCombo->addItem("Sprite Palette 0", OamGraphicsScene::BackgroundType::PALETTE_0_BG);
   backgroundCombo->addItem("Sprite Palette 1", OamGraphicsScene::BackgroundType::PALETTE_1_BG);

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -126,6 +126,12 @@ OamViewer::OamViewer() {
   backgroundCombo->addItem("Black",            OamGraphicsScene::BackgroundType::BLACK);
   sidebarLayout->addRow("Background:", backgroundCombo);
 
+  firstSprite = new QLineEdit;
+  firstSprite->setReadOnly(true);
+  firstSprite->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+  firstSprite->setMinimumWidth(5 * firstSprite->fontMetrics().width('0'));
+  sidebarLayout->addRow("First Sprite:", firstSprite);
+
 
   splitter->setSizes({ INT_MAX / 100 * 2, INT_MAX / 100 * 1 });
   splitter->setStretchFactor(0, 2);
@@ -179,6 +185,8 @@ void OamViewer::refresh() {
   dataModel->refresh();
   graphicsScene->refresh();
   canvas->refresh();
+
+  firstSprite->setText(QString::number(dataModel->firstSprite()));
 
   inRefreshCall = false;
 }

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -3,7 +3,7 @@ class OamCanvas : public QFrame {
   Q_OBJECT
 
 public:
-  OamCanvas(OamDataModel* dataModel, QWidget* parent);
+  OamCanvas(OamDataModel* dataModel, OamGraphicsScene* graphicsScene, QWidget* parent);
   void paintEvent(QPaintEvent*);
 
 public slots:
@@ -12,14 +12,15 @@ public slots:
   void setScale(unsigned);
 
 private:
-  void refreshImage(const OamObject& obj);
-  unsigned maximumOamBaseSize();
-
-private:
   OamDataModel *dataModel;
+  OamGraphicsScene *graphicsScene;
+
   int selected;
   unsigned imageSize;
-  QImage image;
+
+  QColor backgroundColor;
+  QPixmap pixmap;
+  int pixmapScale;
 };
 
 class OamViewer : public Window {
@@ -39,6 +40,13 @@ private:
   OamDataModel *dataModel;
   QSortFilterProxyModel* proxyModel;
 
+  OamGraphicsScene *graphicsScene;
+
+  QVBoxLayout *outerLayout;
+  QSplitter *splitter;
+  QGraphicsView* graphicsView;
+
+  QWidget* bottomWidget;
   QHBoxLayout *layout;
   QTreeView *treeView;
   QVBoxLayout *controlLayout;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -39,7 +39,8 @@ public slots:
   void onZoomChanged(int index);
   void onBackgroundChanged(int index);
 
-  void onSelectionChanged();
+  void onTreeViewSelectionChanged();
+  void onGraphicsSceneSelectedIdsEdited();
 
 private:
   OamDataModel *dataModel;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -71,6 +71,7 @@ private:
   QPushButton *refreshButton;
   QCheckBox *showScreenOutlineBox;
   QComboBox *backgroundCombo;
+  QLineEdit *firstSprite;
 
   QAction* toggleVisibility;
   QAction* showOnlySelectedObjects;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -34,6 +34,8 @@ public slots:
   void show();
   void refresh();
 
+  void onExportClicked();
+
   void onZoomChanged(int index);
   void onBackgroundChanged(int index);
 
@@ -51,12 +53,14 @@ private:
 
   QWidget* bottomWidget;
   QHBoxLayout *layout;
+  QHBoxLayout *buttonLayout;
   QTreeView *treeView;
 
   QFormLayout *sidebarLayout;
   OamCanvas *canvas;
   QComboBox *zoomCombo;
   QCheckBox *autoUpdateBox;
+  QPushButton *exportButton;
   QPushButton *refreshButton;
   QCheckBox *showScreenOutlineBox;
   QComboBox *backgroundCombo;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -35,6 +35,7 @@ public slots:
   void refresh();
 
   void onZoomChanged(int index);
+  void onBackgroundChanged(int index);
 
   void onSelectionChanged();
 
@@ -57,6 +58,8 @@ private:
   QComboBox *zoomCombo;
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
+  QCheckBox *showScreenOutlineBox;
+  QComboBox *backgroundCombo;
 
   bool inRefreshCall;
 };

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -1,23 +1,9 @@
-struct OamObject {
-  unsigned width;
-  unsigned height;
-  signed   xpos;
-  unsigned ypos;
-  unsigned character;
-  unsigned priority;
-  unsigned palette;
-  bool hFlip;
-  bool vFlip;
-  bool table;
-
-  static OamObject getObject(unsigned);
-};
 
 class OamCanvas : public QFrame {
   Q_OBJECT
 
 public:
-  OamCanvas();
+  OamCanvas(OamDataModel* dataModel, QWidget* parent);
   void paintEvent(QPaintEvent*);
 
 public slots:
@@ -30,6 +16,7 @@ private:
   unsigned maximumOamBaseSize();
 
 private:
+  OamDataModel *dataModel;
   int selected;
   unsigned imageSize;
   QImage image;
@@ -46,11 +33,14 @@ public slots:
   void show();
   void refresh();
 
-  void onSelectedChanged();
+  void onSelectionChanged();
 
 private:
+  OamDataModel *dataModel;
+  QSortFilterProxyModel* proxyModel;
+
   QHBoxLayout *layout;
-  QTreeWidget *list;
+  QTreeView *treeView;
   QVBoxLayout *controlLayout;
   OamCanvas *canvas;
   QCheckBox *autoUpdateBox;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -42,6 +42,12 @@ public slots:
   void onTreeViewSelectionChanged();
   void onGraphicsSceneSelectedIdsEdited();
 
+  void onToggleVisibility();
+  void onShowOnlySelectedObjects();
+
+private:
+  void updateActions();
+
 private:
   OamDataModel *dataModel;
   QSortFilterProxyModel* proxyModel;
@@ -65,6 +71,10 @@ private:
   QPushButton *refreshButton;
   QCheckBox *showScreenOutlineBox;
   QComboBox *backgroundCombo;
+
+  QAction* toggleVisibility;
+  QAction* showOnlySelectedObjects;
+  QAction* showAllObjects;
 
   bool inRefreshCall;
 };

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.moc.hpp
@@ -34,6 +34,8 @@ public slots:
   void show();
   void refresh();
 
+  void onZoomChanged(int index);
+
   void onSelectionChanged();
 
 private:
@@ -49,8 +51,10 @@ private:
   QWidget* bottomWidget;
   QHBoxLayout *layout;
   QTreeView *treeView;
-  QVBoxLayout *controlLayout;
+
+  QFormLayout *sidebarLayout;
   OamCanvas *canvas;
+  QComboBox *zoomCombo;
   QCheckBox *autoUpdateBox;
   QPushButton *refreshButton;
 

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -58,6 +58,7 @@ using namespace ruby;
   #include "debugger/ppu/image-grid-widget.moc.hpp"
 
   #include "debugger/ppu/oam-data-model.moc.hpp"
+  #include "debugger/ppu/oam-graphics-scene.moc.hpp"
 
   #include "debugger/ppu/tile-viewer.moc.hpp"
   #include "debugger/ppu/tilemap-viewer.moc.hpp"

--- a/bsnes/ui-qt/ui-base.hpp
+++ b/bsnes/ui-qt/ui-base.hpp
@@ -57,6 +57,8 @@ using namespace ruby;
   #include "debugger/ppu/cgram-widget.moc.hpp"
   #include "debugger/ppu/image-grid-widget.moc.hpp"
 
+  #include "debugger/ppu/oam-data-model.moc.hpp"
+
   #include "debugger/ppu/tile-viewer.moc.hpp"
   #include "debugger/ppu/tilemap-viewer.moc.hpp"
   #include "debugger/ppu/oam-viewer.moc.hpp"


### PR DESCRIPTION
This pull request will add the following features to the Sprite Viewer:

 * A Graphics Scene that displays the objects in OAM to the user.
 * Multiple objects can now be selected.
 * Selecting an object no longer refreshes the Sprite Viewer.
 * Objects can be hidden in the Graphics Scene by either unticking the checkbox in the Table View or by selecting an action in a context menu.
 * The Graphics Scene can be exported to a PNG image.

Development of this pull request was discussed in issue #202


NOTE: This pull request has only been tested for the Qt4 and Qt5 branches in Windows 7 and ArchLinux. It has not been tested on OSX.