### PR TITLE
Tilemap character address

### DIFF
--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -378,9 +378,9 @@ void TileViewer::updateTileInfo() {
     unsigned tileAddr = renderer.address + tileId * renderer.bytesInbetweenTiles();
 
     if(renderer.source == TileRenderer::VRAM) {
-      text = string("Selected Tile Address: ", hex<4>(tileAddr & 0xffff));
+      text = string("Selected Tile Address: 0x", hex<4>(tileAddr & 0xffff));
     } else {
-      text = string("Selected Tile Address: ", hex<6>(tileAddr & 0xffffff));
+      text = string("Selected Tile Address: 0x", hex<6>(tileAddr & 0xffffff));
     }
   } else {
     imageGridWidget->selectNone();

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -376,6 +376,7 @@ void TileViewer::updateTileInfo() {
   string text;
   if(tileId < renderer.nTiles()) {
     unsigned tileAddr = renderer.address + tileId * renderer.bytesInbetweenTiles();
+    if(renderer.isMode7()) tileAddr++;
 
     if(renderer.source == TileRenderer::VRAM) {
       text = string("Selected Tile Address: 0x", hex<4>(tileAddr & 0xffff));

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.cpp
@@ -136,13 +136,19 @@ void TilemapRenderer::drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline
   }
 }
 
-void TilemapRenderer::drawMap8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, unsigned palOffset, bool hFlip, bool vFlip) {
-  unsigned addr = 0;
+unsigned TilemapRenderer::characterAddress(unsigned c) const {
   switch(bitDepth) {
-    case BitDepth::BPP8: addr = (tileAddr + c * 64) & 0xffc0; break;
-    case BitDepth::BPP4: addr = (tileAddr + c * 32) & 0xffe0; break;
-    case BitDepth::BPP2: addr = (tileAddr + c * 16) & 0xfff0; break;
+    case BitDepth::BPP8:        return (tileAddr + c * 64) & 0xffc0;
+    case BitDepth::BPP4:        return (tileAddr + c * 32) & 0xffe0;
+    case BitDepth::BPP2:        return (tileAddr + c * 16) & 0xfff0;
+    case BitDepth::MODE7:       return (c & 0xff) * 128 + 1;
+    case BitDepth::MODE7_EXTBG: return (c & 0xff) * 128 + 1;
   }
+  return 0;
+}
+
+void TilemapRenderer::drawMap8pxTile(QRgb* imgBits, const unsigned wordsPerScanline, unsigned c, unsigned palOffset, bool hFlip, bool vFlip) {
+  unsigned addr = characterAddress(c);
 
   const uint8_t *tile = SNES::memory::vram.data() + addr;
 

--- a/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-renderer.hpp
@@ -21,6 +21,8 @@ public:
 
   void drawTilemap();
 
+  unsigned characterAddress(unsigned c) const;
+
 private:
   void drawMap(unsigned mapAddr, unsigned startX, unsigned startY);
   void drawMapTile(QRgb* imgBits, const unsigned wordsPerScanline, const uint8_t* map);

--- a/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tilemap-viewer.cpp
@@ -325,6 +325,8 @@ void TilemapViewer::updateTileInfoNormal() {
   bool hFlip = tile & 0x4000;
   bool vFlip = tile & 0x8000;
 
+  unsigned charAddr = renderer.characterAddress(character);
+
   string text;
 
   text << "<table>";
@@ -335,6 +337,7 @@ void TilemapViewer::updateTileInfoNormal() {
   text << "<tr><td>Value: </td><td>0x" << hex<4>(tile) << "</td></tr>";
   text << "<tr><td>&nbsp;</td><td>&nbsp;</td></tr>";
   text << "<tr><td>Character: </td><td>" << character << "</td></tr>";
+  text << "<tr><td>Char Address: </td><td>0x" << hex<4>(charAddr) << "</td></tr>";
   text << "<tr><td>Palette: </td><td>" << pal << "</td></tr>";
   text << "<tr><td>Priority: </td><td>" << (unsigned)priority << "</td></tr>";
   text << "<tr><td>hFlip: </td><td>" << (unsigned)hFlip << "</td></tr>";
@@ -353,6 +356,8 @@ void TilemapViewer::updateTileInfoMode7() {
   unsigned addr = yPos * 256 + xPos * 2;
   unsigned tile = vram[addr];
 
+  unsigned charAddr = renderer.characterAddress(tile);
+
   string text;
 
   text << "<table>";
@@ -360,6 +365,7 @@ void TilemapViewer::updateTileInfoMode7() {
   text << "<tr><td>&nbsp;</td><td>&nbsp;</td></tr>";
   text << "<tr><td>Address: </td><td>0x" << hex<4>(addr) << "</td></tr>";
   text << "<tr><td>Value: </td><td>" << tile << "</td></tr>";
+  text << "<tr><td>Char Address: </td><td>0x" << hex<4>(charAddr) << "</td></tr>";
   text << "</table>";
 
   tileInfo->setText(text);


### PR DESCRIPTION
This pull request implements @qwertymodo's request to display the character address in the Tilemap Viewer (Issue #208)

In the interests of consistency, the Tile Viewer has also been modified so the "selected tile address" field matches the Tilemap Viewer's "char address" field.

![character-address](https://user-images.githubusercontent.com/65687/50374055-c5044180-0633-11e9-8881-63d992edbc60.png)
![character-address-mode7](https://user-images.githubusercontent.com/65687/50374056-cafa2280-0633-11e9-8028-5413d4343a57.png)
 