### PR TITLE
Added Visual Studio solution for bsnes

### DIFF
--- a/bsnes/ruby/video/direct3d.cpp
+++ b/bsnes/ruby/video/direct3d.cpp
@@ -1,8 +1,5 @@
-#undef interface
-#define interface struct
 #include <d3d9.h>
 #include <d3dx9.h>
-#undef interface
 
 #define D3DVERTEX (D3DFVF_XYZRHW | D3DFVF_TEX1)
 

--- a/bsnes/snes/audio/audio.cpp
+++ b/bsnes/snes/audio/audio.cpp
@@ -80,7 +80,7 @@ void Audio::add_stream(Stream* stream) {
   
 void Audio::sample(int16 left, int16 right) {
   if(!streams.size()) {
-    system.interface->audio_sample(left, right);
+    system.intf->audio_sample(left, right);
   } else {
     dsp_buffer[dsp_wroffset] = ((uint16)left << 0) + ((uint16)right << 16);
     dsp_wroffset = (dsp_wroffset + 1) & 32767;
@@ -108,7 +108,7 @@ void Audio::flush() {
       right += (int16)(sample >> 16);
     }
 
-    system.interface->audio_sample(
+    system.intf->audio_sample(
       sclamp<16>(left / 2),
       sclamp<16>(right / 2)
     );

--- a/bsnes/snes/cartridge/xml.cpp
+++ b/bsnes/snes/cartridge/xml.cpp
@@ -235,7 +235,7 @@ void Cartridge::xml_parse_necdsp(xml_element &root) {
       for(unsigned n = 0; n < dromsize; n++) necdsp.dataROM[n] = fp.readm(2);
 
       fp.seek(0);
-      uint8_t data[filesize];
+      uint8_t *data = new uint8_t[filesize];
       fp.read(data, filesize);
 
       sha256_ctx sha;
@@ -245,6 +245,8 @@ void Cartridge::xml_parse_necdsp(xml_element &root) {
       sha256_final(&sha);
       sha256_hash(&sha, shahash);
       foreach(n, shahash) programhash.append(hex<2>(n));
+
+      delete[] data;
     }
     fp.close();
   }
@@ -281,9 +283,9 @@ void Cartridge::xml_parse_necdsp(xml_element &root) {
   }
 
   if(programhash == "") {
-    system.interface->message({ "Warning: NEC DSP program ", program, " is missing." });
+    system.intf->message({ "Warning: NEC DSP program ", program, " is missing." });
   } else if(sha256 != "" && sha256 != programhash) {
-    system.interface->message({
+    system.intf->message({
       "Warning: NEC DSP program ", program, " SHA256 is incorrect.\n\n"
       "Expected:\n", sha256, "\n\n"
       "Actual:\n", programhash

--- a/bsnes/snes/input/input.cpp
+++ b/bsnes/snes/input/input.cpp
@@ -14,9 +14,9 @@ uint8 Input::port_read(bool portnumber) {
     case Device::SGBCommander: {
       if(cpu.joylatch() == 0) {
         if(p.counter0 >= 16) return 1;
-        return system.interface->input_poll(portnumber, p.device, 0, p.counter0++);
+        return system.intf->input_poll(portnumber, p.device, 0, p.counter0++);
       } else {
-        return system.interface->input_poll(portnumber, p.device, 0, 0);
+        return system.intf->input_poll(portnumber, p.device, 0, 0);
       }
     } //case Device::Joypad
 
@@ -42,8 +42,8 @@ uint8 Input::port_read(bool portnumber) {
         deviceindex1 = 3;  //controller 4
       }
 
-      return (system.interface->input_poll(portnumber, p.device, deviceindex0, deviceidx) << 0)
-           | (system.interface->input_poll(portnumber, p.device, deviceindex1, deviceidx) << 1);
+      return (system.intf->input_poll(portnumber, p.device, deviceindex0, deviceidx) << 0)
+           | (system.intf->input_poll(portnumber, p.device, deviceindex1, deviceidx) << 1);
     } //case Device::Multitap
 
     case Device::Mouse: {
@@ -65,8 +65,8 @@ uint8 Input::port_read(bool portnumber) {
         case  6: return 0;
         case  7: return 0;
 
-        case  8: return system.interface->input_poll(portnumber, p.device, 0, (unsigned)MouseID::Right);
-        case  9: return system.interface->input_poll(portnumber, p.device, 0, (unsigned)MouseID::Left);
+        case  8: return system.intf->input_poll(portnumber, p.device, 0, (unsigned)MouseID::Right);
+        case  9: return system.intf->input_poll(portnumber, p.device, 0, (unsigned)MouseID::Left);
         case 10: return (p.mouse.speed >> 1) & 1;  //speed (0 = slow, 1 = normal, 2 = fast, 3 = unused)
         case 11: return (p.mouse.speed >> 0) & 1;  // ||
 
@@ -101,7 +101,7 @@ uint8 Input::port_read(bool portnumber) {
 
       if(p.counter0 == 0) {
         //turbo is a switch; toggle is edge sensitive
-        bool turbo = system.interface->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Turbo);
+        bool turbo = system.intf->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Turbo);
         if(turbo && !p.superscope.turbolock) {
           p.superscope.turbo = !p.superscope.turbo;  //toggle state
           p.superscope.turbolock = true;
@@ -112,7 +112,7 @@ uint8 Input::port_read(bool portnumber) {
         //trigger is a button
         //if turbo is active, trigger is level sensitive; otherwise it is edge sensitive
         p.superscope.trigger = false;
-        bool trigger = system.interface->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Trigger);
+        bool trigger = system.intf->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Trigger);
         if(trigger && (p.superscope.turbo || !p.superscope.triggerlock)) {
           p.superscope.trigger = true;
           p.superscope.triggerlock = true;
@@ -121,11 +121,11 @@ uint8 Input::port_read(bool portnumber) {
         }
 
         //cursor is a button; it is always level sensitive
-        p.superscope.cursor = system.interface->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Cursor);
+        p.superscope.cursor = system.intf->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Cursor);
 
         //pause is a button; it is always edge sensitive
         p.superscope.pause = false;
-        bool pause = system.interface->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Pause);
+        bool pause = system.intf->input_poll(portnumber, p.device, 0, (unsigned)SuperScopeID::Pause);
         if(pause && !p.superscope.pauselock) {
           p.superscope.pause = true;
           p.superscope.pauselock = true;
@@ -156,12 +156,12 @@ uint8 Input::port_read(bool portnumber) {
       if(p.counter0 >= 32) return 1;
 
       if(p.counter0 == 0) {
-        p.justifier.trigger1 = system.interface->input_poll(portnumber, p.device, 0, (unsigned)JustifierID::Trigger);
-        p.justifier.start1   = system.interface->input_poll(portnumber, p.device, 0, (unsigned)JustifierID::Start);
+        p.justifier.trigger1 = system.intf->input_poll(portnumber, p.device, 0, (unsigned)JustifierID::Trigger);
+        p.justifier.start1   = system.intf->input_poll(portnumber, p.device, 0, (unsigned)JustifierID::Start);
 
         if(p.device == Device::Justifiers) {
-          p.justifier.trigger2 = system.interface->input_poll(portnumber, p.device, 1, (unsigned)JustifierID::Trigger);
-          p.justifier.start2   = system.interface->input_poll(portnumber, p.device, 1, (unsigned)JustifierID::Start);
+          p.justifier.trigger2 = system.intf->input_poll(portnumber, p.device, 1, (unsigned)JustifierID::Trigger);
+          p.justifier.start2   = system.intf->input_poll(portnumber, p.device, 1, (unsigned)JustifierID::Start);
         } else {
           p.justifier.x2 = -1;
           p.justifier.y2 = -1;
@@ -225,9 +225,9 @@ uint8 Input::port_read(bool portnumber) {
 			return 0;
 		}
 
-        return system.interface->input_poll(portnumber, p.device, 0, p.counter0++);
+        return system.intf->input_poll(portnumber, p.device, 0, p.counter0++);
       } else {
-        return system.interface->input_poll(portnumber, p.device, 0, 0);
+        return system.intf->input_poll(portnumber, p.device, 0, 0);
       }
     } //case Device::NTTDataKeypad
 
@@ -240,13 +240,13 @@ uint8 Input::port_read(bool portnumber) {
 
 //scan all input; update cursor positions if needed
 void Input::update() {
-  system.interface->input_poll();
+  system.intf->input_poll();
   port_t &p = port[1];
 
   switch(p.device) {
     case Device::SuperScope: {
-      int x = system.interface->input_poll(1, p.device, 0, (unsigned)SuperScopeID::X);
-      int y = system.interface->input_poll(1, p.device, 0, (unsigned)SuperScopeID::Y);
+      int x = system.intf->input_poll(1, p.device, 0, (unsigned)SuperScopeID::X);
+      int y = system.intf->input_poll(1, p.device, 0, (unsigned)SuperScopeID::Y);
       x += p.superscope.x;
       y += p.superscope.y;
       p.superscope.x = max(-16, min(256 + 16, x));
@@ -258,15 +258,15 @@ void Input::update() {
 
     case Device::Justifier:
     case Device::Justifiers: {
-      int x1 = system.interface->input_poll(1, p.device, 0, (unsigned)JustifierID::X);
-      int y1 = system.interface->input_poll(1, p.device, 0, (unsigned)JustifierID::Y);
+      int x1 = system.intf->input_poll(1, p.device, 0, (unsigned)JustifierID::X);
+      int y1 = system.intf->input_poll(1, p.device, 0, (unsigned)JustifierID::Y);
       x1 += p.justifier.x1;
       y1 += p.justifier.y1;
       p.justifier.x1 = max(-16, min(256 + 16, x1));
       p.justifier.y1 = max(-16, min(240 + 16, y1));
 
-      int x2 = system.interface->input_poll(1, p.device, 1, (unsigned)JustifierID::X);
-      int y2 = system.interface->input_poll(1, p.device, 1, (unsigned)JustifierID::Y);
+      int x2 = system.intf->input_poll(1, p.device, 1, (unsigned)JustifierID::X);
+      int y2 = system.intf->input_poll(1, p.device, 1, (unsigned)JustifierID::Y);
       x2 += p.justifier.x2;
       y2 += p.justifier.y2;
       p.justifier.x2 = max(-16, min(256 + 16, x2));
@@ -360,8 +360,8 @@ void Input::poll() {
     port[i].counter1 = 0;
 
     if(port[i].device == Device::Mouse) {
-      int x = system.interface->input_poll(i, port[i].device, 0, (unsigned)MouseID::X);  //-n = left, 0 = center, +n = right
-      int y = system.interface->input_poll(i, port[i].device, 0, (unsigned)MouseID::Y);  //-n = up,   0 = center, +n = down
+      int x = system.intf->input_poll(i, port[i].device, 0, (unsigned)MouseID::X);  //-n = left, 0 = center, +n = right
+      int y = system.intf->input_poll(i, port[i].device, 0, (unsigned)MouseID::Y);  //-n = up,   0 = center, +n = down
 
       port[i].mouse.dx = x < 0;
       port[i].mouse.dy = y < 0;

--- a/bsnes/snes/libsnes/libsnes.cpp
+++ b/bsnes/snes/libsnes/libsnes.cpp
@@ -31,7 +31,7 @@ struct Interface : public SNES::Interface {
   }
 };
 
-static Interface interface;
+static Interface intf;
 
 unsigned snes_library_revision_major(void) {
   return 1;
@@ -42,19 +42,19 @@ unsigned snes_library_revision_minor(void) {
 }
 
 void snes_set_video_refresh(snes_video_refresh_t video_refresh) {
-  interface.pvideo_refresh = video_refresh;
+  intf.pvideo_refresh = video_refresh;
 }
 
 void snes_set_audio_sample(snes_audio_sample_t audio_sample) {
-  interface.paudio_sample = audio_sample;
+  intf.paudio_sample = audio_sample;
 }
 
 void snes_set_input_poll(snes_input_poll_t input_poll) {
-  interface.pinput_poll = input_poll;
+  intf.pinput_poll = input_poll;
 }
 
 void snes_set_input_state(snes_input_state_t input_state) {
-  interface.pinput_state = input_state;
+  intf.pinput_state = input_state;
 }
 
 void snes_set_controller_port_device(bool port, unsigned device) {
@@ -66,7 +66,7 @@ void snes_set_cartridge_basename(const char *basename) {
 }
 
 void snes_init(void) {
-  SNES::system.init(&interface);
+  SNES::system.init(&intf);
   SNES::input.port_set_device(0, SNES::Input::Device::Joypad);
   SNES::input.port_set_device(1, SNES::Input::Device::Joypad);
 }

--- a/bsnes/snes/system/system.cpp
+++ b/bsnes/snes/system/system.cpp
@@ -71,8 +71,8 @@ bool System::runthreadtosave(cothread_t& thread) {
 }
 
 void System::init(Interface *interface_) {
-  interface = interface_;
-  assert(interface != 0);
+  intf = interface_;
+  assert(intf != 0);
 
   supergameboy.init();
   superfx.init();
@@ -236,7 +236,7 @@ void System::scanline() {
 void System::frame() {
 }
 
-System::System() : interface(0) {
+System::System() : intf(0) {
   region = Region::Autodetect;
   expansion = ExpansionPortDevice::None;
 }

--- a/bsnes/snes/system/system.hpp
+++ b/bsnes/snes/system/system.hpp
@@ -30,7 +30,7 @@ public:
   System();
 
 private:
-  Interface *interface;
+  Interface *intf;
   bool runthreadtosave(cothread_t&);
 
   void serialize(serializer&);

--- a/bsnes/snes/video/video.cpp
+++ b/bsnes/snes/video/video.cpp
@@ -72,13 +72,13 @@ void Video::update() {
     }
   }
 
-  system.interface->video_extras(data, width, height);
+  system.intf->video_extras(data, width, height);
 
   if(frame_interlace) {
     height <<= 1;
   }
 
-  system.interface->video_refresh(ppu.output + 1024, width, height);
+  system.intf->video_refresh(ppu.output + 1024, width, height);
 
   frame_hires = false;
   frame_interlace = false;

--- a/bsnes/ui-qt/application/application.cpp
+++ b/bsnes/ui-qt/application/application.cpp
@@ -159,7 +159,7 @@ int Application::main(int &argc, char **argv) {
   config().load(configFilename);
   mapper().bind();
   init();
-  SNES::system.init(&interface);
+  SNES::system.init(&intf);
   mainWindow->system_loadSpecial_superGameBoy->setVisible(SNES::supergameboy.opened());
 
   parseArguments();

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -615,12 +615,12 @@ void MainWindow::recordMovieFromHere() {
 
 void MainWindow::saveScreenshot() {
   //tell SNES::Interface to save a screenshot at the next video_refresh() event
-  interface.saveScreenshot = true;
+  intf.saveScreenshot = true;
 }
 
 void MainWindow::saveSPC() {
   //tell the S-SMP core to save a SPC after the next note-on
-  interface.captureSPC();
+  intf.captureSPC();
 }
 
 void MainWindow::loadState() {

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -36,7 +36,7 @@ OamDataModel::OamDataModel(QObject* parent)
 {
   assert(COLUMN_STRINGS.size() == N_COLUMNS);
   assert(FLIP_STRINGS.size() == 4);
-  assert(OBJECT_SIZE_TABLE == N_OAM_BASE_SIZES);
+  assert(OBJECT_SIZE_TABLE.size() == N_OAM_BASE_SIZES);
 
   for(OamObject& obj : mOamObjects) {
     obj.visible = true;

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.moc.hpp
@@ -1,3 +1,4 @@
+#undef small
 
 struct OamObject {
   signed   xpos;

--- a/bsnes/ui-qt/input/userinterface-general.cpp
+++ b/bsnes/ui-qt/input/userinterface-general.cpp
@@ -46,10 +46,10 @@ struct ToggleCheatSystem : HotkeyInput {
 struct CaptureScreenshot : HotkeyInput {
   void pressed() {
     //tell SNES::Interface to save a screenshot at the next video_refresh() event
-    interface.saveScreenshot = true;
+    intf.saveScreenshot = true;
   }
 
-  CaptureScreenshot() : HotkeyInput("Capture Screenshot", "input.userInterface.general.captureScreenshot") {
+  CaptureScreenshot() : HotkeyInput("Capture Screenshot", "input.userintf.general.captureScreenshot") {
     userInterfaceGeneral.attach(this);
   }
 } captureScreenshot;
@@ -57,7 +57,7 @@ struct CaptureScreenshot : HotkeyInput {
 struct CaptureSPC : HotkeyInput {
   void pressed() {
     //tell the S-SMP core to save a SPC after the next note-on
-    interface.captureSPC();
+    intf.captureSPC();
   }
 
   CaptureSPC() : HotkeyInput("Capture SPC Dump", "input.userInterface.general.captureSPC") {

--- a/bsnes/ui-qt/interface.cpp
+++ b/bsnes/ui-qt/interface.cpp
@@ -1,4 +1,4 @@
-Interface interface;
+Interface intf;
 
 void Interface::video_extras(uint16_t *data, unsigned width, unsigned height) {
     if (music.loaded()) music.render((uint16_t*)data, 1024, width, height);

--- a/bsnes/ui-qt/interface.hpp
+++ b/bsnes/ui-qt/interface.hpp
@@ -15,4 +15,4 @@ public:
   unsigned framesExecuted;
 };
 
-extern Interface interface;
+extern Interface intf;

--- a/bsnes/ui-qt/resource/resource.rc
+++ b/bsnes/ui-qt/resource/resource.rc
@@ -1,2 +1,2 @@
-1 24 "../../data/bsnes.Manifest"
-IDI_ICON1 ICON DISCARDABLE "../../data/bsnes.ico"
+1 24 "data/bsnes.Manifest"
+IDI_ICON1 ICON DISCARDABLE "data/bsnes.ico"

--- a/bsnes/ui-qt/resource/resource.rc
+++ b/bsnes/ui-qt/resource/resource.rc
@@ -1,2 +1,2 @@
-1 24 "data/bsnes.Manifest"
-IDI_ICON1 ICON DISCARDABLE "data/bsnes.ico"
+1 24 "../../data/bsnes.Manifest"
+IDI_ICON1 ICON DISCARDABLE "../../data/bsnes.ico"

--- a/bsnes/ui-qt/utility/utility.cpp
+++ b/bsnes/ui-qt/utility/utility.cpp
@@ -30,9 +30,9 @@ void Utility::updateSystemState() {
     text = "Power off";
   } else if(application.pause == true || application.autopause == true) {
     text = "Paused";
-  } else if(interface.framesUpdated == true) {
-    interface.framesUpdated = false;
-    text << interface.framesExecuted;
+  } else if(intf.framesUpdated == true) {
+    intf.framesUpdated = false;
+    text << intf.framesExecuted;
     text << " fps";
   } else {
     //nothing to update

--- a/bsnes/vstudio/bsnes/bsnes.sln
+++ b/bsnes/vstudio/bsnes/bsnes.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30517.126
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bsnes", "bsnes.vcxproj", "{42D864F9-AFDA-4EF7-99C3-218E982AA46E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug-Accuracy|x64 = Debug-Accuracy|x64
+		Debug-Accuracy|x86 = Debug-Accuracy|x86
+		Debug-Compatibility|x64 = Debug-Compatibility|x64
+		Debug-Compatibility|x86 = Debug-Compatibility|x86
+		Debug-Performance|x64 = Debug-Performance|x64
+		Debug-Performance|x86 = Debug-Performance|x86
+		Release-Accuracy|x64 = Release-Accuracy|x64
+		Release-Accuracy|x86 = Release-Accuracy|x86
+		Release-Compatibility|x64 = Release-Compatibility|x64
+		Release-Compatibility|x86 = Release-Compatibility|x86
+		Release-Performance|x64 = Release-Performance|x64
+		Release-Performance|x86 = Release-Performance|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Accuracy|x64.ActiveCfg = Debug-Accuracy|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Accuracy|x64.Build.0 = Debug-Accuracy|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Accuracy|x86.ActiveCfg = Debug-Accuracy|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Accuracy|x86.Build.0 = Debug-Accuracy|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Compatibility|x64.ActiveCfg = Debug-Compatibility|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Compatibility|x64.Build.0 = Debug-Compatibility|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Compatibility|x86.ActiveCfg = Debug-Compatibility|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Compatibility|x86.Build.0 = Debug-Compatibility|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Performance|x64.ActiveCfg = Debug-Performance|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Performance|x64.Build.0 = Debug-Performance|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Performance|x86.ActiveCfg = Debug-Performance|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Debug-Performance|x86.Build.0 = Debug-Performance|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Accuracy|x64.ActiveCfg = Release-Accuracy|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Accuracy|x64.Build.0 = Release-Accuracy|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Accuracy|x86.ActiveCfg = Release-Accuracy|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Accuracy|x86.Build.0 = Release-Accuracy|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Compatibility|x64.ActiveCfg = Release-Compatibility|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Compatibility|x64.Build.0 = Release-Compatibility|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Compatibility|x86.ActiveCfg = Release-Compatibility|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Compatibility|x86.Build.0 = Release-Compatibility|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Performance|x64.ActiveCfg = Release-Performance|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Performance|x64.Build.0 = Release-Performance|x64
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Performance|x86.ActiveCfg = Release-Performance|Win32
+		{42D864F9-AFDA-4EF7-99C3-218E982AA46E}.Release-Performance|x86.Build.0 = Release-Performance|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {79215649-444D-4FCC-97DD-3CD012E031FA}
+	EndGlobalSection
+EndGlobal

--- a/bsnes/vstudio/bsnes/bsnes.vcxproj
+++ b/bsnes/vstudio/bsnes/bsnes.vcxproj
@@ -1,0 +1,5576 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug-Accuracy|Win32">
+      <Configuration>Debug-Accuracy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Accuracy|x64">
+      <Configuration>Debug-Accuracy</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Compatibility|Win32">
+      <Configuration>Debug-Compatibility</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Compatibility|x64">
+      <Configuration>Debug-Compatibility</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Performance|Win32">
+      <Configuration>Debug-Performance</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Performance|x64">
+      <Configuration>Debug-Performance</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Accuracy|Win32">
+      <Configuration>Release-Accuracy</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Accuracy|x64">
+      <Configuration>Release-Accuracy</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Compatibility|Win32">
+      <Configuration>Release-Compatibility</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Compatibility|x64">
+      <Configuration>Release-Compatibility</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Performance|Win32">
+      <Configuration>Release-Performance</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Performance|x64">
+      <Configuration>Release-Performance</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{42d864f9-afda-4ef7-99c3-218e982aa46e}</ProjectGuid>
+    <RootNamespace>bsnes</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_PERFORMANCE;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_COMPATIBILITY;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_ACCURACY;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_PERFORMANCE;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_COMPATIBILITY;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_ACCURACY;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_PERFORMANCE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_COMPATIBILITY;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_ACCURACY;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_PERFORMANCE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_COMPATIBILITY;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUGGER;VIDEO_DIRECT3D;AUDIO_DIRECTSOUND;INPUT_DIRECTINPUT;PROFILE_ACCURACY;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(QTDIR)\include;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWidgets;../../;../../snes/;../../ui-qt/debugger/tools/qhexedit2/;../../ui-qt/resource/;../../../common/;../../../common/nall/qt/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>c:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;$(QTDIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>D3d9.lib;Dsound.lib;Dinput8.lib;Dxguid.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\common\zlib\adler32.c" />
+    <ClCompile Include="..\..\..\common\zlib\crc32.c" />
+    <ClCompile Include="..\..\..\common\zlib\inffast.c" />
+    <ClCompile Include="..\..\..\common\zlib\inflate.c" />
+    <ClCompile Include="..\..\..\common\zlib\inftrees.c" />
+    <ClCompile Include="..\..\..\common\zlib\zutil.c" />
+    <ClCompile Include="..\..\libco\amd64.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libco\libco.c" />
+    <ClCompile Include="..\..\libco\x86.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\audio\directsound.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\input\directinput.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\ruby.cpp" />
+    <ClCompile Include="..\..\ruby\ruby_audio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\ruby_impl.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\video\direct3d.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\cpu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\dma.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\timing.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\dsp.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\SPC_DSP.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\memory\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\ppu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\addsub.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\bg.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\cache.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\line.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\mode7.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\oam.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\render.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\windows.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\audio\audio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\cartridge.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\xml.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cheat\cheat.cpp" />
+    <ClCompile Include="..\..\snes\chip\bsx\bsx.cpp" />
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_base.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_cart.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_flash.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\bus.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\cx4.cpp" />
+    <ClCompile Include="..\..\snes\chip\cx4\data.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\instructions.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\registers.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\msu1\msu1.cpp" />
+    <ClCompile Include="..\..\snes\chip\msu1\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\disassembler.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\necdsp.cpp" />
+    <ClCompile Include="..\..\snes\chip\necdsp\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\obc1\obc1.cpp" />
+    <ClCompile Include="..\..\snes\chip\obc1\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\bus\bus.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\dma\dma.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\memory\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\sa1.cpp" />
+    <ClCompile Include="..\..\snes\chip\sa1\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sdd1\sdd1.cpp" />
+    <ClCompile Include="..\..\snes\chip\sdd1\sdd1emu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sdd1\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\serial\serial.cpp" />
+    <ClCompile Include="..\..\snes\chip\serial\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\decomp.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\spc7110.cpp" />
+    <ClCompile Include="..\..\snes\chip\srtc\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\srtc\srtc.cpp" />
+    <ClCompile Include="..\..\snes\chip\st0018\st0018.cpp" />
+    <ClCompile Include="..\..\snes\chip\superfx\bus\bus.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\core.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\opcodes.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\opcode_table.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\disasm\disasm.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\memory\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\superfx.cpp" />
+    <ClCompile Include="..\..\snes\chip\superfx\timing\timing.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\supergameboy.cpp" />
+    <ClCompile Include="..\..\snes\config\config.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\algorithms.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\core.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\disassembler\disassembler.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_misc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_pc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_read.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_rmw.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_write.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\table.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\cpu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\debugger\analyst.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\dma\dma.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\memory\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\irq.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\joypad.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\timing.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\brr.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\counter.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\dsp.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\echo.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\envelope.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\gaussian.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\misc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\voice.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\input\input.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\memory\memory.cpp" />
+    <ClCompile Include="..\..\snes\memory\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\background\background.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\background\mode7.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\counter\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\ppu.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\screen\screen.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\sprite\list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\sprite\sprite.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\window\window.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\scheduler\scheduler.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\algorithms.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\core.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\disassembler\disassembler.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_misc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_mov.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_pc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_read.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_rmw.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\table.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\debugger\debugger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\iplrom.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\memory\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\mmio\mmio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\smp.cpp" />
+    <ClCompile Include="..\..\snes\smp\timing\timing.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\random.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\serialization.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\system.cpp" />
+    <ClCompile Include="..\..\snes\video\video.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\application.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\arguments.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\init.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\about.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\base.cpp" />
+    <ClCompile Include="..\..\ui-qt\base\filebrowser.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\htmlviewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\loader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\main.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\stateselect.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\cartridge\cartridge.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\config.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\debugger.cpp" />
+    <ClCompile Include="..\..\ui-qt\debugger\debuggerview.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\disassemblerview.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\common_processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\cpu_processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\sfx_processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\smp_processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbolsview.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\fma_symbol_file.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\vice_label_file.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\wla_symbol_file.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_file_adapters.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_map.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\base-renderer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\cgram-viewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\cgram-widget.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\image-grid-widget.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-data-model.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-graphics-scene.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-viewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tile-renderer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tile-viewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tilemap-renderer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tilemap-viewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\registeredit.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\breakpoint.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\memory.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\properties.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\qhexedit2\commands.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\qhexedit2\qhexedit.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tracer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\controller.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\input.cpp" />
+    <ClCompile Include="..\..\ui-qt\input\userinterface-emulationspeed.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-general.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-states.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-system.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-videosettings.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\interface.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\filter.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\music.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\reader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\main.cpp" />
+    <ClCompile Include="..\..\ui-qt\movie\movie.cpp" />
+    <ClCompile Include="..\..\ui-qt\platform\platform_win.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\advanced.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\audio.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\bsx.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\input.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\paths.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\settings.cpp" />
+    <ClCompile Include="..\..\ui-qt\settings\video.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\state\state.cpp" />
+    <ClCompile Include="..\..\ui-qt\tools\cheateditor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\cheatfinder.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\effecttoggle.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\manifestviewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\soundviewer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\statemanager.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\tools.cpp" />
+    <ClCompile Include="..\..\ui-qt\utility\system-state.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\utility\utility.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\utility\window.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\common\nall\algorithm.hpp" />
+    <ClInclude Include="..\..\..\common\nall\any.hpp" />
+    <ClInclude Include="..\..\..\common\nall\array.hpp" />
+    <ClInclude Include="..\..\..\common\nall\base64.hpp" />
+    <ClInclude Include="..\..\..\common\nall\bit.hpp" />
+    <ClInclude Include="..\..\..\common\nall\bps\delta.hpp" />
+    <ClInclude Include="..\..\..\common\nall\bps\linear.hpp" />
+    <ClInclude Include="..\..\..\common\nall\bps\metadata.hpp" />
+    <ClInclude Include="..\..\..\common\nall\bps\patch.hpp" />
+    <ClInclude Include="..\..\..\common\nall\concept.hpp" />
+    <ClInclude Include="..\..\..\common\nall\config.hpp" />
+    <ClInclude Include="..\..\..\common\nall\crc32.hpp" />
+    <ClInclude Include="..\..\..\common\nall\detect.hpp" />
+    <ClInclude Include="..\..\..\common\nall\dictionary.hpp" />
+    <ClInclude Include="..\..\..\common\nall\directory.hpp" />
+    <ClInclude Include="..\..\..\common\nall\dl.hpp" />
+    <ClInclude Include="..\..\..\common\nall\endian.hpp" />
+    <ClInclude Include="..\..\..\common\nall\file.hpp" />
+    <ClInclude Include="..\..\..\common\nall\filemap.hpp" />
+    <ClInclude Include="..\..\..\common\nall\foreach.hpp" />
+    <ClInclude Include="..\..\..\common\nall\function.hpp" />
+    <ClInclude Include="..\..\..\common\nall\input.hpp" />
+    <ClInclude Include="..\..\..\common\nall\lzss.hpp" />
+    <ClInclude Include="..\..\..\common\nall\moduloarray.hpp" />
+    <ClInclude Include="..\..\..\common\nall\platform.hpp" />
+    <ClInclude Include="..\..\..\common\nall\priorityqueue.hpp" />
+    <ClInclude Include="..\..\..\common\nall\property.hpp" />
+    <CustomBuild Include="..\..\..\common\nall\qt\check-action.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\..\common\nall\qt\check-delegate.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\..\common\nall\qt\combo-delegate.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\..\common\nall\qt\concept.hpp" />
+    <CustomBuild Include="..\..\..\common\nall\qt\file-dialog.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\..\common\nall\qt\radio-action.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\..\common\nall\qt\window.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\..\common\nall\random.hpp" />
+    <ClInclude Include="..\..\..\common\nall\serial.hpp" />
+    <ClInclude Include="..\..\..\common\nall\serializer.hpp" />
+    <ClInclude Include="..\..\..\common\nall\sha256.hpp" />
+    <ClInclude Include="..\..\..\common\nall\snes\cartridge.hpp" />
+    <ClInclude Include="..\..\..\common\nall\snes\cpu.hpp" />
+    <ClInclude Include="..\..\..\common\nall\snes\sgb.hpp" />
+    <ClInclude Include="..\..\..\common\nall\snes\smp.hpp" />
+    <ClInclude Include="..\..\..\common\nall\sort.hpp" />
+    <ClInclude Include="..\..\..\common\nall\static.hpp" />
+    <ClInclude Include="..\..\..\common\nall\stdint.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\base.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\bsv.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\cast.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\compare.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\convert.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\core.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\filename.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\math.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\platform.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\replace.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\split.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\strl.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\strpos.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\trim.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\utility.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\variadic.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\wrapper.hpp" />
+    <ClInclude Include="..\..\..\common\nall\string\xml.hpp" />
+    <ClInclude Include="..\..\..\common\nall\ups.hpp" />
+    <ClInclude Include="..\..\..\common\nall\utf8.hpp" />
+    <ClInclude Include="..\..\..\common\nall\utility.hpp" />
+    <ClInclude Include="..\..\..\common\nall\varint.hpp" />
+    <ClInclude Include="..\..\..\common\nall\vector.hpp" />
+    <ClInclude Include="..\..\..\common\zlib\crc32.h" />
+    <ClInclude Include="..\..\..\common\zlib\inffast.h" />
+    <ClInclude Include="..\..\..\common\zlib\inffixed.h" />
+    <ClInclude Include="..\..\..\common\zlib\inflate.h" />
+    <ClInclude Include="..\..\..\common\zlib\inftrees.h" />
+    <ClInclude Include="..\..\..\common\zlib\zconf.h" />
+    <ClInclude Include="..\..\..\common\zlib\zlib.h" />
+    <ClInclude Include="..\..\..\common\zlib\zutil.h" />
+    <ClInclude Include="..\..\libco\libco.h" />
+    <ClInclude Include="..\..\ruby\audio.hpp" />
+    <ClInclude Include="..\..\ruby\input.hpp" />
+    <ClInclude Include="..\..\ruby\ruby.hpp" />
+    <ClInclude Include="..\..\ruby\video.hpp" />
+    <ClInclude Include="..\..\snes\alt\cpu\cpu.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_common.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_config.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_endian.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_source.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\dsp.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\SPC_DSP.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\debugger\debugger.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\memory\memory.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\mmio\mmio.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\ppu.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\render\render.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\audio\audio.hpp" />
+    <ClInclude Include="..\..\snes\cartridge\cartridge.hpp" />
+    <ClInclude Include="..\..\snes\cheat\cheat-inline.hpp" />
+    <ClInclude Include="..\..\snes\cheat\cheat.hpp" />
+    <ClInclude Include="..\..\snes\chip\bsx\bsx.hpp" />
+    <ClInclude Include="..\..\snes\chip\chip.hpp" />
+    <ClInclude Include="..\..\snes\chip\cx4\bus.hpp" />
+    <ClInclude Include="..\..\snes\chip\cx4\cx4.hpp" />
+    <ClInclude Include="..\..\snes\chip\msu1\msu1.hpp" />
+    <ClInclude Include="..\..\snes\chip\necdsp\necdsp.hpp" />
+    <ClInclude Include="..\..\snes\chip\necdsp\registers.hpp" />
+    <ClInclude Include="..\..\snes\chip\obc1\obc1.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\bus\bus.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\debugger\debugger.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\dma\dma.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\memory\memory.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\mmio\mmio.hpp" />
+    <ClInclude Include="..\..\snes\chip\sa1\sa1.hpp" />
+    <ClInclude Include="..\..\snes\chip\sdd1\sdd1.hpp" />
+    <ClInclude Include="..\..\snes\chip\sdd1\sdd1emu.hpp" />
+    <ClInclude Include="..\..\snes\chip\serial\serial.hpp" />
+    <ClInclude Include="..\..\snes\chip\spc7110\decomp.hpp" />
+    <ClInclude Include="..\..\snes\chip\spc7110\spc7110.hpp" />
+    <ClInclude Include="..\..\snes\chip\srtc\srtc.hpp" />
+    <ClInclude Include="..\..\snes\chip\st0018\st0018.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\bus\bus.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\core\core.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\core\registers.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\debugger\debugger.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\disasm\disasm.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\memory\memory.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\mmio\mmio.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\superfx.hpp" />
+    <ClInclude Include="..\..\snes\chip\superfx\timing\timing.hpp" />
+    <ClInclude Include="..\..\snes\chip\supergameboy\debugger\debugger.hpp" />
+    <ClInclude Include="..\..\snes\chip\supergameboy\supergameboy.hpp" />
+    <ClInclude Include="..\..\snes\config\config.hpp" />
+    <ClInclude Include="..\..\snes\cpu\core\core.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\disassembler\disassembler.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\memory.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\registers.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\cpu.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\debugger\analyst.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\debugger\debugger.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\dma\dma.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\memory\memory.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\mmio\mmio.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\timing\timing.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\debugger\debugger.hpp" />
+    <ClInclude Include="..\..\snes\dsp\debugger\debugger.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\dsp\dsp.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\input\input.hpp" />
+    <ClInclude Include="..\..\snes\interface\interface.hpp" />
+    <ClInclude Include="..\..\snes\memory\memory-inline.hpp" />
+    <ClInclude Include="..\..\snes\memory\memory.hpp" />
+    <ClInclude Include="..\..\snes\ppu\background\background.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\counter\counter-inline.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\counter\counter.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\debugger\debugger.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\mmio\mmio.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\ppu.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\screen\screen.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\sprite\sprite.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\window\window.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-accuracy.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-compatibility.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-performance.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\scheduler\scheduler.hpp" />
+    <ClInclude Include="..\..\snes\smp\core\core.hpp" />
+    <ClInclude Include="..\..\snes\smp\core\disassembler\disassembler.hpp" />
+    <ClInclude Include="..\..\snes\smp\core\memory.hpp" />
+    <ClInclude Include="..\..\snes\smp\core\registers.hpp" />
+    <ClInclude Include="..\..\snes\smp\debugger\debugger.hpp" />
+    <ClInclude Include="..\..\snes\smp\memory\memory.hpp" />
+    <ClInclude Include="..\..\snes\smp\mmio\mmio.hpp" />
+    <ClInclude Include="..\..\snes\smp\smp.hpp" />
+    <ClInclude Include="..\..\snes\smp\timing\timing.hpp" />
+    <ClInclude Include="..\..\snes\snes.hpp" />
+    <ClInclude Include="..\..\snes\system\system.hpp" />
+    <ClInclude Include="..\..\snes\video\video.hpp" />
+    <CustomBuild Include="..\..\ui-qt\application\application.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\about.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\filebrowser.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\htmlviewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\loader.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\main.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\base\stateselect.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\cartridge\cartridge.hpp" />
+    <ClInclude Include="..\..\ui-qt\config.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\debugger.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\debuggerview.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\disassembler\disassemblerview.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\line.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\common_processor.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\cpu_processor.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\processor.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\sfx_processor.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\smp_processor.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\disassembler\symbolsview.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\fma_symbol_file.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\symbol_file_interface.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\vice_label_file.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\wla_symbol_file.hpp" />
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_file_adapters.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_map.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\base-renderer.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\cgram-viewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\cgram-widget.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\image-grid-widget.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\oam-data-model.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\oam-graphics-scene.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\oam-viewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tile-renderer.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\tile-viewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tilemap-renderer.hpp" />
+    <CustomBuild Include="..\..\ui-qt\debugger\ppu\tilemap-viewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\registeredit.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\breakpoint.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\memory.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\properties.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\qhexedit2\commands.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\qhexedit2\qhexedit.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tracer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\input\controller.hpp" />
+    <ClInclude Include="..\..\ui-qt\input\input.hpp" />
+    <ClInclude Include="..\..\ui-qt\input\userinterface.hpp" />
+    <ClInclude Include="..\..\ui-qt\interface.hpp" />
+    <ClInclude Include="..\..\ui-qt\link\filter.hpp" />
+    <ClInclude Include="..\..\ui-qt\link\music.hpp" />
+    <ClInclude Include="..\..\ui-qt\link\reader.hpp" />
+    <ClInclude Include="..\..\ui-qt\movie\movie.hpp" />
+    <CustomBuild Include="..\..\ui-qt\settings\advanced.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\audio.moc.hpp">
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\bsx.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\input.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\paths.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\settings.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\settings\video.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\state\state.hpp" />
+    <CustomBuild Include="..\..\ui-qt\tools\cheateditor.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\cheatfinder.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\effecttoggle.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\manifestviewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\soundviewer.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\statemanager.moc.hpp">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\tools\tools.moc.hpp">
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename);%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using MOC</Message>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\moc.exe -i "%(FullPath)" -o "%(RootDir)%(Directory)%(Filename)"</Command>
+    </CustomBuild>
+    <ClInclude Include="..\..\ui-qt\ui-base.hpp" />
+    <ClInclude Include="..\..\ui-qt\utility\utility.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-break.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-run.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step-out.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step-over.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\folder-new.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\go-up.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-check-off.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-check-on.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-radio-off.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-radio-on.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-find.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-code.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-data.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-unknown.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-code.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-data.png" />
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-unknown.png" />
+    <Image Include="..\..\ui-qt\data\logo.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\ui-qt\data\documentation.html" />
+    <None Include="..\..\ui-qt\data\license.html" />
+    <CustomBuild Include="..\..\ui-qt\resource\resource.qrc">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">$(QTDIR)\bin\rcc.exe %(FullPath) -o %(RootDir)%(Directory)%(Filename).rcc</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|Win32'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Compatibility|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Compatibility|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Accuracy|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Performance|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release-Accuracy|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">Compiling %(Filename)%(Extension) using RCC</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug-Performance|x64'">%(RootDir)%(Directory)%(Filename).rcc;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\..\..\common\zlib\readme.txt" />
+    <Text Include="..\..\..\common\zlib\zlib.txt" />
+    <Text Include="..\..\ui-qt\debugger\tools\qhexedit2\license.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/bsnes/vstudio/bsnes/bsnes.vcxproj.filters
+++ b/bsnes/vstudio/bsnes/bsnes.vcxproj.filters
@@ -1,0 +1,1853 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="snes">
+      <UniqueIdentifier>{acd77031-02f8-49a2-bbf1-25c69facfcdd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt">
+      <UniqueIdentifier>{70cea245-a73f-408e-b43d-4577fe26a4cb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\cpu">
+      <UniqueIdentifier>{626fcbc7-09f9-489b-928a-685320937ccf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\dsp">
+      <UniqueIdentifier>{fd4f25dc-2534-4e88-b17f-1a5b7bc84fe4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\ppu">
+      <UniqueIdentifier>{e8362c26-2292-4e08-bdaf-b31cb577811a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\ppu\debugger">
+      <UniqueIdentifier>{3c14ee14-c3b0-4c7e-bd61-7b01730c0919}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\ppu\memory">
+      <UniqueIdentifier>{18258502-b1ec-4df4-b32d-33b55955f64b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\ppu\mmio">
+      <UniqueIdentifier>{2c51348c-ac6a-4b5d-b515-46b912f63e58}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\alt\ppu\render">
+      <UniqueIdentifier>{cad0ee95-7364-428e-9699-bdb4a1754d6d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\audio">
+      <UniqueIdentifier>{1798fb10-d931-4e41-92c9-64a3222c4ae0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cartridge">
+      <UniqueIdentifier>{3c91d563-1ab8-4df1-b7f2-6dfc2c0f3f40}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cheat">
+      <UniqueIdentifier>{f6bbb465-9106-4729-8e7f-8e527f5c0e11}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip">
+      <UniqueIdentifier>{48b91aa9-cf7f-490b-9d0e-516c34129c0e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\config">
+      <UniqueIdentifier>{57ac3a6e-4010-486a-ad41-1c195df9bd01}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu">
+      <UniqueIdentifier>{601b8ef2-a300-4eba-98d8-a15212df8613}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\debugger">
+      <UniqueIdentifier>{d3974109-0028-4b92-ba84-6305f5a0b690}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\dsp">
+      <UniqueIdentifier>{a8e9772a-0d1c-4ad6-8168-ac1a1d427c62}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\input">
+      <UniqueIdentifier>{30b00000-dd79-49a1-a059-9852e52163ee}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\interface">
+      <UniqueIdentifier>{c23fc12a-cae5-4e7a-a5b4-e6a988bffcee}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\memory">
+      <UniqueIdentifier>{b87146bf-127f-4f16-87a9-280a1ab3a66c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu">
+      <UniqueIdentifier>{eac77925-d76a-487f-b3f4-729f3292e12c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\scheduler">
+      <UniqueIdentifier>{d65eebe3-05f6-47dd-b0ae-099836f3ffdc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp">
+      <UniqueIdentifier>{1df7a165-809e-434d-bb91-052511536cb0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\system">
+      <UniqueIdentifier>{921bd4f7-a76a-464d-98de-d7c6f93092d3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\video">
+      <UniqueIdentifier>{03dc6de4-65e9-4e22-beea-9af350968971}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\bsx">
+      <UniqueIdentifier>{14025810-8974-4e7e-a374-5d3ee2480fb5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\cx4">
+      <UniqueIdentifier>{8a2970cb-c9b4-41bb-8bc3-1c5e0535d6ae}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\msu1">
+      <UniqueIdentifier>{86944617-8e1f-4081-9503-ee657549b12c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\necdsp">
+      <UniqueIdentifier>{2d81073c-06f4-466f-ac20-c93bcc846eae}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\obc1">
+      <UniqueIdentifier>{f74e47c9-7c62-4b46-b02f-3770ea8d4a6b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1">
+      <UniqueIdentifier>{e1fc50dd-72ef-44ed-a758-b2b0c3251b6e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\supergameboy">
+      <UniqueIdentifier>{b7c5faf4-c3d3-4996-975e-b642d77b7914}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sdd1">
+      <UniqueIdentifier>{9ed6318f-da0c-4318-9fee-c961c97d692f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\serial">
+      <UniqueIdentifier>{d4737b51-2409-4e57-ba36-388847edffde}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\spc7110">
+      <UniqueIdentifier>{6efb6bad-0d4a-4fc8-a061-2460a8bce976}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\srtc">
+      <UniqueIdentifier>{eccfcce6-b9e0-4494-8a7d-c3cbce288ac9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\st0018">
+      <UniqueIdentifier>{b6c6e828-c371-44bd-aec8-9a069688cd44}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx">
+      <UniqueIdentifier>{20a649d2-5a4a-4758-acd9-fd08fb8d11bd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1\bus">
+      <UniqueIdentifier>{13032fc1-0577-40e9-85d4-5d8124e1b272}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1\debugger">
+      <UniqueIdentifier>{9d11d620-3303-4198-994f-716bf436fd98}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1\dma">
+      <UniqueIdentifier>{fb13c71f-7fd8-467e-b3f5-420327cc2177}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1\memory">
+      <UniqueIdentifier>{b5c7f29c-6c51-40ef-b23a-978a09867680}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\sa1\mmio">
+      <UniqueIdentifier>{0323c3ef-81d4-4d9e-ac2d-cc6aa83b0f9f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\bus">
+      <UniqueIdentifier>{c96aed74-c04f-4566-b2c4-10a3953a46d6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\core">
+      <UniqueIdentifier>{e999255b-61d7-4c81-9716-ab98c20c14aa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\debugger">
+      <UniqueIdentifier>{e7649b04-a877-4884-96f3-d46b7d42eb80}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\disasm">
+      <UniqueIdentifier>{db79c623-8c33-4cbe-bfe2-eb16bca18d39}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\memory">
+      <UniqueIdentifier>{e267b9c3-a579-41c4-a9e8-f2a4b93bf017}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\mmio">
+      <UniqueIdentifier>{78c204cc-e5c6-40d5-b0c7-28d791f720bc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\superfx\timing">
+      <UniqueIdentifier>{cea11459-df08-4fe2-bde7-681e1c5cd356}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\chip\supergameboy\debugger">
+      <UniqueIdentifier>{4acd9689-bae2-4dfc-b78e-e3e26062c437}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\core">
+      <UniqueIdentifier>{14a6ff35-16ff-416e-9def-9fa53c24e93e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\debugger">
+      <UniqueIdentifier>{aabbaa14-6d0f-49b5-95b2-b0d2a211e04e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\dma">
+      <UniqueIdentifier>{cea517a4-3e9b-4a80-91d6-a8fd24324268}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\memory">
+      <UniqueIdentifier>{1c3f4c6a-aaf3-4da7-94eb-dd9b5a16cb6b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\mmio">
+      <UniqueIdentifier>{e8734f1d-7789-4921-989b-109b58a52338}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\timing">
+      <UniqueIdentifier>{e8a6a10c-e33b-4850-86ba-a7d333ad182a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\cpu\core\disassembler">
+      <UniqueIdentifier>{a484e997-e50e-4d33-b87d-637842768a7c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\dsp\debugger">
+      <UniqueIdentifier>{dd1d04c3-ef77-47f6-99a1-b70bb32e5300}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\background">
+      <UniqueIdentifier>{659d386d-3ff2-43cf-8152-07392ace1eef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\counter">
+      <UniqueIdentifier>{51f2c766-fbfc-484a-a5cb-fc2ea0a4555a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\debugger">
+      <UniqueIdentifier>{31fe7a10-ac1b-4a26-81f8-5fd3cc4bd301}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\mmio">
+      <UniqueIdentifier>{0b954590-3027-4ad7-afb3-108e9309638a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\screen">
+      <UniqueIdentifier>{0bc2e82d-9bd6-4ca2-bc86-1f9abe95374c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\sprite">
+      <UniqueIdentifier>{e85cc1cb-0950-4487-8830-7eaa8f9d45ee}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\ppu\window">
+      <UniqueIdentifier>{9f9eb3a2-facd-4222-b484-cf428810ef1b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\core">
+      <UniqueIdentifier>{aff14859-0cd9-4a72-8cd8-285ea41b969b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\debugger">
+      <UniqueIdentifier>{537b06c8-1725-4703-a294-9ef3115bd1a9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\memory">
+      <UniqueIdentifier>{fed788f7-d79e-4b83-841d-5a7b4c441ecb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\mmio">
+      <UniqueIdentifier>{9ca72061-358c-49ba-89ad-72ffc78fc2fb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\timing">
+      <UniqueIdentifier>{f6a99ada-84ea-4699-b944-8884e825c808}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="snes\smp\core\disassembler">
+      <UniqueIdentifier>{24753958-aead-4c41-8f80-c64c05ad4cea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ruby">
+      <UniqueIdentifier>{a4bbf361-2b35-43e1-a1b4-108f46279664}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ruby\audio">
+      <UniqueIdentifier>{6e3a43c3-e7cd-44f4-af77-b18a5270847a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ruby\input">
+      <UniqueIdentifier>{2348049f-6872-4199-b1ad-f3f2037cf557}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ruby\video">
+      <UniqueIdentifier>{042405c8-db97-4147-a10f-560369a56104}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt">
+      <UniqueIdentifier>{f79a6510-9483-4238-b730-d44cef56a0ec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\application">
+      <UniqueIdentifier>{2d800095-b254-4c2b-b25c-4e4d86fc37bf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\base">
+      <UniqueIdentifier>{57293206-a35e-4eed-aa5e-bf8f9d4cee61}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\cartridge">
+      <UniqueIdentifier>{804f84f4-c308-4acb-9e68-5ab1f4d343cb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\data">
+      <UniqueIdentifier>{8672c5f2-dea6-434c-a63b-6d9d94e3d355}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\data\icons-16x16">
+      <UniqueIdentifier>{9a51d029-9462-41e1-b091-9c49c3370918}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger">
+      <UniqueIdentifier>{3e82b754-3305-44c8-b27f-fcda6bf9f858}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\disassembler">
+      <UniqueIdentifier>{694c75c8-8ae1-43a0-a0f3-dadb9901b62a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\disassembler\processor">
+      <UniqueIdentifier>{d38a4f1f-0474-4d28-b567-1a79a16e1121}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\disassembler\symbols">
+      <UniqueIdentifier>{72b3d432-f56c-4d0b-a3e7-f87a4341e102}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\disassembler\symbols\adapters">
+      <UniqueIdentifier>{005cc49e-0588-4a77-85f1-fb968a8f815e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\ppu">
+      <UniqueIdentifier>{f13602a0-e01b-4429-8023-41efeb05d01b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\tools">
+      <UniqueIdentifier>{77b15f02-9346-4292-a6a3-63dec9407187}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\debugger\tools\qhexedit2">
+      <UniqueIdentifier>{6744e85c-04b5-4624-98da-31fc3f2c6e58}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\input">
+      <UniqueIdentifier>{ec5dd2b6-5820-42b2-b598-e566ab91fac5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\link">
+      <UniqueIdentifier>{a42c83cd-678a-430a-92c5-75e7e3dd123d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\movie">
+      <UniqueIdentifier>{17a483f6-7ea5-48b0-95b7-caf0b10a6f48}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\platform">
+      <UniqueIdentifier>{9cd0b4b9-18a4-4b7c-8e52-4499d88ff1c1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\resource">
+      <UniqueIdentifier>{7d1a8e75-3830-4ad6-9a68-043f5f0a4c61}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\settings">
+      <UniqueIdentifier>{af5af218-a29b-496e-a765-dc3bd1f53e90}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\state">
+      <UniqueIdentifier>{e235539e-3461-403c-ab3c-4fd343608101}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\tools">
+      <UniqueIdentifier>{d4a73649-d17c-4d29-88fb-7c3a153a2f58}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ui-qt\utility">
+      <UniqueIdentifier>{43892867-6aa5-4686-9aaf-5a2c0129511a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common">
+      <UniqueIdentifier>{60fe0955-d12b-4c0b-986c-e630fc82bffd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\nall">
+      <UniqueIdentifier>{f8b7264f-ca84-4a7e-9d77-48cec5348288}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\zlib">
+      <UniqueIdentifier>{e21f8e58-e334-4f8d-a2ba-927153365ab3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\nall\bps">
+      <UniqueIdentifier>{1a72ba3c-9d91-43c4-bdf9-ab9dd97a7a97}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\nall\qt">
+      <UniqueIdentifier>{20c63d81-799b-4857-b334-55bc9a027dd7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\nall\string">
+      <UniqueIdentifier>{fabff825-473b-48c8-8f64-b2fde98619d1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="common\nall\snes">
+      <UniqueIdentifier>{390e9dcd-7e41-4a8b-a005-8d259da51a8b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libco">
+      <UniqueIdentifier>{7e4a35b9-7b93-41fc-a22c-699b7a2e207f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\snes\alt\cpu\cpu.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\dma.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\memory.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\mmio.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\serialization.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\cpu\timing.cpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\dsp.cpp">
+      <Filter>snes\alt\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\serialization.cpp">
+      <Filter>snes\alt\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\dsp\SPC_DSP.cpp">
+      <Filter>snes\alt\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\debugger\debugger.cpp">
+      <Filter>snes\alt\ppu\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\memory\memory.cpp">
+      <Filter>snes\alt\ppu\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\mmio\mmio.cpp">
+      <Filter>snes\alt\ppu\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\addsub.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\bg.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\cache.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\line.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\mode7.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\oam.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\render.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\render\windows.cpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\ppu.cpp">
+      <Filter>snes\alt\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\alt\ppu\serialization.cpp">
+      <Filter>snes\alt\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\audio\audio.cpp">
+      <Filter>snes\audio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\cartridge.cpp">
+      <Filter>snes\cartridge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\serialization.cpp">
+      <Filter>snes\cartridge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cartridge\xml.cpp">
+      <Filter>snes\cartridge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cheat\cheat.cpp">
+      <Filter>snes\cheat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx.cpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_base.cpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_cart.cpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\bsx_flash.cpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\bsx\serialization.cpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\bus.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\cx4.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\data.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\instructions.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\memory.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\registers.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\cx4\serialization.cpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\msu1\msu1.cpp">
+      <Filter>snes\chip\msu1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\msu1\serialization.cpp">
+      <Filter>snes\chip\msu1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\disassembler.cpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\memory.cpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\necdsp.cpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\necdsp\serialization.cpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\obc1\obc1.cpp">
+      <Filter>snes\chip\obc1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\obc1\serialization.cpp">
+      <Filter>snes\chip\obc1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\sa1.cpp">
+      <Filter>snes\chip\sa1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\serialization.cpp">
+      <Filter>snes\chip\sa1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\bus\bus.cpp">
+      <Filter>snes\chip\sa1\bus</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\debugger\debugger.cpp">
+      <Filter>snes\chip\sa1\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\dma\dma.cpp">
+      <Filter>snes\chip\sa1\dma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\memory\memory.cpp">
+      <Filter>snes\chip\sa1\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sa1\mmio\mmio.cpp">
+      <Filter>snes\chip\sa1\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sdd1\sdd1.cpp">
+      <Filter>snes\chip\sdd1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sdd1\sdd1emu.cpp">
+      <Filter>snes\chip\sdd1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\sdd1\serialization.cpp">
+      <Filter>snes\chip\sdd1</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\serial\serial.cpp">
+      <Filter>snes\chip\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\serial\serialization.cpp">
+      <Filter>snes\chip\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\decomp.cpp">
+      <Filter>snes\chip\spc7110</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\serialization.cpp">
+      <Filter>snes\chip\spc7110</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\spc7110\spc7110.cpp">
+      <Filter>snes\chip\spc7110</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\srtc\serialization.cpp">
+      <Filter>snes\chip\srtc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\srtc\srtc.cpp">
+      <Filter>snes\chip\srtc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\st0018\st0018.cpp">
+      <Filter>snes\chip\st0018</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\serialization.cpp">
+      <Filter>snes\chip\superfx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\superfx.cpp">
+      <Filter>snes\chip\superfx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\bus\bus.cpp">
+      <Filter>snes\chip\superfx\bus</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\core.cpp">
+      <Filter>snes\chip\superfx\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\opcode_table.cpp">
+      <Filter>snes\chip\superfx\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\core\opcodes.cpp">
+      <Filter>snes\chip\superfx\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\debugger\debugger.cpp">
+      <Filter>snes\chip\superfx\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\disasm\disasm.cpp">
+      <Filter>snes\chip\superfx\disasm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\memory\memory.cpp">
+      <Filter>snes\chip\superfx\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\mmio\mmio.cpp">
+      <Filter>snes\chip\superfx\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\superfx\timing\timing.cpp">
+      <Filter>snes\chip\superfx\timing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\debugger\debugger.cpp">
+      <Filter>snes\chip\supergameboy\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\serialization.cpp">
+      <Filter>snes\chip\supergameboy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\chip\supergameboy\supergameboy.cpp">
+      <Filter>snes\chip\supergameboy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\config\config.cpp">
+      <Filter>snes\config</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\cpu.cpp">
+      <Filter>snes\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\serialization.cpp">
+      <Filter>snes\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\algorithms.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\core.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_misc.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_pc.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_read.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_rmw.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\opcode_write.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\serialization.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\table.cpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\core\disassembler\disassembler.cpp">
+      <Filter>snes\cpu\core\disassembler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\debugger\analyst.cpp">
+      <Filter>snes\cpu\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\debugger\debugger.cpp">
+      <Filter>snes\cpu\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\dma\dma.cpp">
+      <Filter>snes\cpu\dma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\memory\memory.cpp">
+      <Filter>snes\cpu\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\mmio\mmio.cpp">
+      <Filter>snes\cpu\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\irq.cpp">
+      <Filter>snes\cpu\timing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\joypad.cpp">
+      <Filter>snes\cpu\timing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\cpu\timing\timing.cpp">
+      <Filter>snes\cpu\timing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\debugger\debugger.cpp">
+      <Filter>snes\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\debugger\debugger.cpp">
+      <Filter>snes\dsp\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\brr.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\counter.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\dsp.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\echo.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\envelope.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\gaussian.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\misc.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\serialization.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\dsp\voice.cpp">
+      <Filter>snes\dsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\input\input.cpp">
+      <Filter>snes\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\memory\memory.cpp">
+      <Filter>snes\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\memory\serialization.cpp">
+      <Filter>snes\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\ppu.cpp">
+      <Filter>snes\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\serialization.cpp">
+      <Filter>snes\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\background\background.cpp">
+      <Filter>snes\ppu\background</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\background\mode7.cpp">
+      <Filter>snes\ppu\background</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\counter\serialization.cpp">
+      <Filter>snes\ppu\counter</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\debugger\debugger.cpp">
+      <Filter>snes\ppu\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\mmio\mmio.cpp">
+      <Filter>snes\ppu\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\screen\screen.cpp">
+      <Filter>snes\ppu\screen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\sprite\list.cpp">
+      <Filter>snes\ppu\sprite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\sprite\sprite.cpp">
+      <Filter>snes\ppu\sprite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\ppu\window\window.cpp">
+      <Filter>snes\ppu\window</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\scheduler\scheduler.cpp">
+      <Filter>snes\scheduler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\iplrom.cpp">
+      <Filter>snes\smp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\serialization.cpp">
+      <Filter>snes\smp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\smp.cpp">
+      <Filter>snes\smp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\disassembler\disassembler.cpp">
+      <Filter>snes\smp\core\disassembler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\algorithms.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\core.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_misc.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_mov.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_pc.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_read.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\opcode_rmw.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\serialization.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\core\table.cpp">
+      <Filter>snes\smp\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\debugger\debugger.cpp">
+      <Filter>snes\smp\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\memory\memory.cpp">
+      <Filter>snes\smp\memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\mmio\mmio.cpp">
+      <Filter>snes\smp\mmio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\smp\timing\timing.cpp">
+      <Filter>snes\smp\timing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\random.cpp">
+      <Filter>snes\system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\serialization.cpp">
+      <Filter>snes\system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\system\system.cpp">
+      <Filter>snes\system</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\snes\video\video.cpp">
+      <Filter>snes\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\ruby.cpp">
+      <Filter>ruby</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\ruby_audio.cpp">
+      <Filter>ruby</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\ruby_impl.cpp">
+      <Filter>ruby</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\audio\directsound.cpp">
+      <Filter>ruby\audio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\input\directinput.cpp">
+      <Filter>ruby\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ruby\video\direct3d.cpp">
+      <Filter>ruby\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\application.cpp">
+      <Filter>ui-qt\application</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\arguments.cpp">
+      <Filter>ui-qt\application</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\application\init.cpp">
+      <Filter>ui-qt\application</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\about.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\base.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\filebrowser.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\htmlviewer.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\loader.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\main.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\base\stateselect.cpp">
+      <Filter>ui-qt\base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\cartridge\cartridge.cpp">
+      <Filter>ui-qt\cartridge</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\common_processor.cpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\cpu_processor.cpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\processor.cpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\sfx_processor.cpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\processor\smp_processor.cpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\fma_symbol_file.cpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\vice_label_file.cpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\wla_symbol_file.cpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_file_adapters.cpp">
+      <Filter>ui-qt\debugger\disassembler\symbols</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_map.cpp">
+      <Filter>ui-qt\debugger\disassembler\symbols</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\disassemblerview.cpp">
+      <Filter>ui-qt\debugger\disassembler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\disassembler\symbolsview.cpp">
+      <Filter>ui-qt\debugger\disassembler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\base-renderer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\cgram-viewer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\cgram-widget.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\image-grid-widget.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-data-model.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-graphics-scene.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\oam-viewer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tile-renderer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tile-viewer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tilemap-renderer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\ppu\tilemap-viewer.cpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\qhexedit2\commands.cpp">
+      <Filter>ui-qt\debugger\tools\qhexedit2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\qhexedit2\qhexedit.cpp">
+      <Filter>ui-qt\debugger\tools\qhexedit2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\breakpoint.cpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\memory.cpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tools\properties.cpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\debugger.cpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\debuggerview.cpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\registeredit.cpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\debugger\tracer.cpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\controller.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\input.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-emulationspeed.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-general.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-states.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-system.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\input\userinterface-videosettings.cpp">
+      <Filter>ui-qt\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\filter.cpp">
+      <Filter>ui-qt\link</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\music.cpp">
+      <Filter>ui-qt\link</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\link\reader.cpp">
+      <Filter>ui-qt\link</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\movie\movie.cpp">
+      <Filter>ui-qt\movie</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\platform\platform_win.cpp">
+      <Filter>ui-qt\platform</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\advanced.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\audio.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\bsx.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\input.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\paths.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\settings.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\settings\video.cpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\state\state.cpp">
+      <Filter>ui-qt\state</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\cheateditor.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\cheatfinder.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\effecttoggle.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\manifestviewer.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\soundviewer.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\statemanager.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\tools\tools.cpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\utility\system-state.cpp">
+      <Filter>ui-qt\utility</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\utility\utility.cpp">
+      <Filter>ui-qt\utility</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\utility\window.cpp">
+      <Filter>ui-qt\utility</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\config.cpp">
+      <Filter>ui-qt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\interface.cpp">
+      <Filter>ui-qt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ui-qt\main.cpp">
+      <Filter>ui-qt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\adler32.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\crc32.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\inffast.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\inflate.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\inftrees.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\zlib\zutil.c">
+      <Filter>common\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libco\libco.c">
+      <Filter>libco</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libco\amd64.c">
+      <Filter>libco</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libco\x86.c">
+      <Filter>libco</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\snes\alt\cpu\cpu.hpp">
+      <Filter>snes\alt\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_common.h">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_config.h">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_endian.h">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\blargg_source.h">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\dsp.hpp">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\dsp\SPC_DSP.h">
+      <Filter>snes\alt\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\debugger\debugger.hpp">
+      <Filter>snes\alt\ppu\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\memory\memory.hpp">
+      <Filter>snes\alt\ppu\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\mmio\mmio.hpp">
+      <Filter>snes\alt\ppu\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\render\render.hpp">
+      <Filter>snes\alt\ppu\render</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\alt\ppu\ppu.hpp">
+      <Filter>snes\alt\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\audio\audio.hpp">
+      <Filter>snes\audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cartridge\cartridge.hpp">
+      <Filter>snes\cartridge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cheat\cheat.hpp">
+      <Filter>snes\cheat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cheat\cheat-inline.hpp">
+      <Filter>snes\cheat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\chip.hpp">
+      <Filter>snes\chip</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\bsx\bsx.hpp">
+      <Filter>snes\chip\bsx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\cx4\bus.hpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\cx4\cx4.hpp">
+      <Filter>snes\chip\cx4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\msu1\msu1.hpp">
+      <Filter>snes\chip\msu1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\necdsp\necdsp.hpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\necdsp\registers.hpp">
+      <Filter>snes\chip\necdsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\obc1\obc1.hpp">
+      <Filter>snes\chip\obc1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\sa1.hpp">
+      <Filter>snes\chip\sa1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\bus\bus.hpp">
+      <Filter>snes\chip\sa1\bus</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\debugger\debugger.hpp">
+      <Filter>snes\chip\sa1\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\dma\dma.hpp">
+      <Filter>snes\chip\sa1\dma</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\memory\memory.hpp">
+      <Filter>snes\chip\sa1\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sa1\mmio\mmio.hpp">
+      <Filter>snes\chip\sa1\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sdd1\sdd1.hpp">
+      <Filter>snes\chip\sdd1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\sdd1\sdd1emu.hpp">
+      <Filter>snes\chip\sdd1</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\serial\serial.hpp">
+      <Filter>snes\chip\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\spc7110\decomp.hpp">
+      <Filter>snes\chip\spc7110</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\spc7110\spc7110.hpp">
+      <Filter>snes\chip\spc7110</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\srtc\srtc.hpp">
+      <Filter>snes\chip\srtc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\st0018\st0018.hpp">
+      <Filter>snes\chip\st0018</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\superfx.hpp">
+      <Filter>snes\chip\superfx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\bus\bus.hpp">
+      <Filter>snes\chip\superfx\bus</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\core\core.hpp">
+      <Filter>snes\chip\superfx\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\core\registers.hpp">
+      <Filter>snes\chip\superfx\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\debugger\debugger.hpp">
+      <Filter>snes\chip\superfx\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\disasm\disasm.hpp">
+      <Filter>snes\chip\superfx\disasm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\memory\memory.hpp">
+      <Filter>snes\chip\superfx\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\mmio\mmio.hpp">
+      <Filter>snes\chip\superfx\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\superfx\timing\timing.hpp">
+      <Filter>snes\chip\superfx\timing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\supergameboy\debugger\debugger.hpp">
+      <Filter>snes\chip\supergameboy\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\chip\supergameboy\supergameboy.hpp">
+      <Filter>snes\chip\supergameboy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\config\config.hpp">
+      <Filter>snes\config</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\cpu.hpp">
+      <Filter>snes\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\core.hpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\memory.hpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\registers.hpp">
+      <Filter>snes\cpu\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\core\disassembler\disassembler.hpp">
+      <Filter>snes\cpu\core\disassembler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\debugger\analyst.hpp">
+      <Filter>snes\cpu\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\debugger\debugger.hpp">
+      <Filter>snes\cpu\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\dma\dma.hpp">
+      <Filter>snes\cpu\dma</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\memory\memory.hpp">
+      <Filter>snes\cpu\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\mmio\mmio.hpp">
+      <Filter>snes\cpu\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\cpu\timing\timing.hpp">
+      <Filter>snes\cpu\timing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\debugger\debugger.hpp">
+      <Filter>snes\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\dsp\debugger\debugger.hpp">
+      <Filter>snes\dsp\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\dsp\dsp.hpp">
+      <Filter>snes\dsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\input\input.hpp">
+      <Filter>snes\input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\interface\interface.hpp">
+      <Filter>snes\interface</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\memory\memory.hpp">
+      <Filter>snes\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\memory\memory-inline.hpp">
+      <Filter>snes\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\ppu.hpp">
+      <Filter>snes\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\background\background.hpp">
+      <Filter>snes\ppu\background</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\counter\counter.hpp">
+      <Filter>snes\ppu\counter</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\counter\counter-inline.hpp">
+      <Filter>snes\ppu\counter</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\debugger\debugger.hpp">
+      <Filter>snes\ppu\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\mmio\mmio.hpp">
+      <Filter>snes\ppu\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\screen\screen.hpp">
+      <Filter>snes\ppu\screen</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\sprite\sprite.hpp">
+      <Filter>snes\ppu\sprite</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\ppu\window\window.hpp">
+      <Filter>snes\ppu\window</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\scheduler\scheduler.hpp">
+      <Filter>snes\scheduler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\smp.hpp">
+      <Filter>snes\smp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\core\disassembler\disassembler.hpp">
+      <Filter>snes\smp\core\disassembler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\core\core.hpp">
+      <Filter>snes\smp\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\core\memory.hpp">
+      <Filter>snes\smp\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\core\registers.hpp">
+      <Filter>snes\smp\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\debugger\debugger.hpp">
+      <Filter>snes\smp\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\memory\memory.hpp">
+      <Filter>snes\smp\memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\mmio\mmio.hpp">
+      <Filter>snes\smp\mmio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\smp\timing\timing.hpp">
+      <Filter>snes\smp\timing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\system\system.hpp">
+      <Filter>snes\system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\video\video.hpp">
+      <Filter>snes\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-accuracy.hpp">
+      <Filter>snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-compatibility.hpp">
+      <Filter>snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\profile-performance.hpp">
+      <Filter>snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\snes\snes.hpp">
+      <Filter>snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ruby\audio.hpp">
+      <Filter>ruby</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ruby\input.hpp">
+      <Filter>ruby</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ruby\ruby.hpp">
+      <Filter>ruby</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ruby\video.hpp">
+      <Filter>ruby</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\application\application.moc.hpp">
+      <Filter>ui-qt\application</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\base\filebrowser.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\base\htmlviewer.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\base\loader.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\base\main.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\base\stateselect.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\cartridge\cartridge.hpp">
+      <Filter>ui-qt\cartridge</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\common_processor.hpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\cpu_processor.hpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\processor.hpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\sfx_processor.hpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\processor\smp_processor.hpp">
+      <Filter>ui-qt\debugger\disassembler\processor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\fma_symbol_file.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\symbol_file_interface.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\vice_label_file.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\adapters\wla_symbol_file.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols\adapters</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_file_adapters.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbols\symbol_map.moc.hpp">
+      <Filter>ui-qt\debugger\disassembler\symbols</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\disassemblerview.moc.hpp">
+      <Filter>ui-qt\debugger\disassembler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\line.hpp">
+      <Filter>ui-qt\debugger\disassembler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\disassembler\symbolsview.moc.hpp">
+      <Filter>ui-qt\debugger\disassembler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\base-renderer.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\cgram-viewer.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\cgram-widget.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\image-grid-widget.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\oam-data-model.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\oam-graphics-scene.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\oam-viewer.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tile-renderer.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tile-viewer.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tilemap-renderer.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\ppu\tilemap-viewer.moc.hpp">
+      <Filter>ui-qt\debugger\ppu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\tools\qhexedit2\qhexedit.moc.hpp">
+      <Filter>ui-qt\debugger\tools\qhexedit2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\tools\breakpoint.moc.hpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\tools\memory.moc.hpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\tools\properties.moc.hpp">
+      <Filter>ui-qt\debugger\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\debuggerview.moc.hpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\registeredit.moc.hpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\debugger\tracer.moc.hpp">
+      <Filter>ui-qt\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\input\controller.hpp">
+      <Filter>ui-qt\input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\input\input.hpp">
+      <Filter>ui-qt\input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\input\userinterface.hpp">
+      <Filter>ui-qt\input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\link\filter.hpp">
+      <Filter>ui-qt\link</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\link\music.hpp">
+      <Filter>ui-qt\link</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\link\reader.hpp">
+      <Filter>ui-qt\link</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\movie\movie.hpp">
+      <Filter>ui-qt\movie</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\advanced.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\audio.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\bsx.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\input.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\paths.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\settings.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\settings\video.moc.hpp">
+      <Filter>ui-qt\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\state\state.hpp">
+      <Filter>ui-qt\state</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\cheateditor.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\cheatfinder.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\effecttoggle.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\manifestviewer.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\soundviewer.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\statemanager.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\tools\tools.moc.hpp">
+      <Filter>ui-qt\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\utility\utility.hpp">
+      <Filter>ui-qt\utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\config.hpp">
+      <Filter>ui-qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\interface.hpp">
+      <Filter>ui-qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ui-qt\ui-base.hpp">
+      <Filter>ui-qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\algorithm.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\any.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\array.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\base64.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\bit.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\concept.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\config.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\crc32.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\detect.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\dictionary.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\directory.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\dl.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\endian.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\file.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\filemap.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\foreach.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\function.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\input.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\lzss.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\moduloarray.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\platform.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\priorityqueue.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\property.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\random.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\serial.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\serializer.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\sha256.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\sort.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\static.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\stdint.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\ups.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\utf8.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\utility.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\varint.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\vector.hpp">
+      <Filter>common\nall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\bps\delta.hpp">
+      <Filter>common\nall\bps</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\bps\linear.hpp">
+      <Filter>common\nall\bps</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\bps\metadata.hpp">
+      <Filter>common\nall\bps</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\bps\patch.hpp">
+      <Filter>common\nall\bps</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\check-action.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\check-delegate.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\combo-delegate.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\concept.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\file-dialog.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\radio-action.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\qt\window.moc.hpp">
+      <Filter>common\nall\qt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\snes\cartridge.hpp">
+      <Filter>common\nall\snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\snes\cpu.hpp">
+      <Filter>common\nall\snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\snes\sgb.hpp">
+      <Filter>common\nall\snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\snes\smp.hpp">
+      <Filter>common\nall\snes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\base.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\bsv.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\cast.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\compare.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\convert.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\core.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\filename.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\math.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\platform.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\replace.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\split.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\strl.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\strpos.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\trim.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\utility.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\variadic.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\wrapper.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\nall\string\xml.hpp">
+      <Filter>common\nall\string</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\crc32.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\inffast.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\inffixed.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\inflate.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\inftrees.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\zconf.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\zlib.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\common\zlib\zutil.h">
+      <Filter>common\zlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libco\libco.h">
+      <Filter>libco</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-break.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-run.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step-out.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\dbg-step-over.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\folder-new.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\go-up.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-check-off.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-check-on.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-radio-off.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\item-radio-on.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-find.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-code.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-data.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-next-unknown.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-code.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-data.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\icons-16x16\mem-prev-unknown.png">
+      <Filter>ui-qt\data\icons-16x16</Filter>
+    </Image>
+    <Image Include="..\..\ui-qt\data\logo.png">
+      <Filter>ui-qt\data</Filter>
+    </Image>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\ui-qt\data\documentation.html">
+      <Filter>ui-qt\data</Filter>
+    </None>
+    <None Include="..\..\ui-qt\data\license.html">
+      <Filter>ui-qt\data</Filter>
+    </None>
+    <None Include="..\..\ui-qt\resource\resource.qrc">
+      <Filter>ui-qt\resource</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\..\ui-qt\debugger\tools\qhexedit2\license.txt">
+      <Filter>ui-qt\debugger\tools\qhexedit2</Filter>
+    </Text>
+    <Text Include="..\..\..\common\zlib\readme.txt">
+      <Filter>common\zlib</Filter>
+    </Text>
+    <Text Include="..\..\..\common\zlib\zlib.txt">
+      <Filter>common\zlib</Filter>
+    </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\ui-qt\base\about.moc.hpp">
+      <Filter>ui-qt\base</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\debugger.moc.hpp">
+      <Filter>ui-qt\debugger</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\ui-qt\debugger\tools\qhexedit2\commands.moc.hpp">
+      <Filter>ui-qt\debugger\tools\qhexedit2</Filter>
+    </CustomBuild>
+  </ItemGroup>
+</Project>

--- a/bsnes/vstudio/bsnes/bsnes.vcxproj.user
+++ b/bsnes/vstudio/bsnes/bsnes.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/common/nall/bps/patch.hpp
+++ b/common/nall/bps/patch.hpp
@@ -78,10 +78,11 @@ bool bpspatch::modify(const uint8_t *data, unsigned size) {
   modifyTargetSize = decode();
   modifyMarkupSize = decode();
 
-  char buffer[modifyMarkupSize + 1];
+  char *buffer = new char[modifyMarkupSize + 1];
   for(unsigned n = 0; n < modifyMarkupSize; n++) buffer[n] = modifyData[offset++];
   buffer[modifyMarkupSize] = 0;
-  metadataString = (const char*)buffer;
+  metadataString.assign((const char*)buffer);
+  delete[] buffer;
 
   return true;
 }

--- a/common/nall/platform.hpp
+++ b/common/nall/platform.hpp
@@ -22,7 +22,7 @@
   #include <io.h>
   #include <direct.h>
   #include <shlobj.h>
-  #undef interface
+  
   #define bsnesexport __declspec(dllexport)
 #else
   #include <unistd.h>

--- a/common/nall/utf8.hpp
+++ b/common/nall/utf8.hpp
@@ -13,7 +13,6 @@
 #define _WIN32_WINNT 0x0501
 #define NOMINMAX
 #include <windows.h>
-#undef interface
 
 namespace nall {
   //UTF-8 to UTF-16


### PR DESCRIPTION
1) Renamed `interface` to `intf` to not interfere with DirectX SDK.
2) Fixed `oam-data-model.cpp` assert.
3) Fixed an old style allocation of buffer which is not correct for a modern C++ in: `patch.hpp`, `xml.cpp`

In general, this PR allows to compile BSNES-PLUS in any of Accuracy/Compatibility/Performance modes in Visual Studio, with DIRECTX usage as Video/Audio/Input drivers.