### PR TITLE
replace deprecated qt api with recommended functions

### DIFF
--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -141,7 +141,7 @@ Debugger::Debugger() {
   console->setReadOnly(true);
   console->setFont(QFont(Style::Monospace));
   console->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-  console->setMinimumWidth((98 + 4) * console->fontMetrics().width(' '));
+  console->setMinimumWidth((98 + 4) * console->fontMetrics().horizontalAdvance(' '));
   console->setMinimumHeight((6 + 1) * console->fontMetrics().height());
   consoleLayout->addWidget(console);
 

--- a/bsnes/ui-qt/debugger/disassembler/disassemblerview.cpp
+++ b/bsnes/ui-qt/debugger/disassembler/disassemblerview.cpp
@@ -34,7 +34,7 @@ void DisassemblerView::init() {
 void DisassemblerView::setFont(const QFont &font) {
   QWidget::setFont(font);
 
-  charWidth = fontMetrics().width(QLatin1Char('2'));
+  charWidth = fontMetrics().horizontalAdvance(QLatin1Char('2'));
   charHeight = fontMetrics().height() + 1;
   charPadding = charWidth / 2;
   headerHeight = charHeight + 3;

--- a/bsnes/ui-qt/debugger/disassembler/symbolsview.cpp
+++ b/bsnes/ui-qt/debugger/disassembler/symbolsview.cpp
@@ -20,7 +20,7 @@ SymbolsView::SymbolsView(DisasmProcessor *processor) : processor(processor) {
   list = new QTreeWidget;
   list->setColumnCount(3);
   list->setHeaderLabels(QStringList() << "Address" << "Name" << "Description");
-  list->setColumnWidth(1, list->fontMetrics().width("  123456789  "));
+  list->setColumnWidth(1, list->fontMetrics().horizontalAdvance("  123456789  "));
   list->setAllColumnsShowFocus(true);
   list->sortByColumn(0, Qt::AscendingOrder);
   list->setRootIsDecorated(false);

--- a/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/cgram-widget.cpp
@@ -60,7 +60,7 @@ void CgramWidget::setSelected(int s) {
 
 void CgramWidget::paintEvent(QPaintEvent*) {
   QPainter painter(this);
-  painter.setRenderHints(0);
+  painter.setRenderHints({});
   painter.drawImage(0, 0, image->scaled(image->width() * scale, image->height() * scale, Qt::IgnoreAspectRatio, Qt::FastTransformation));
 
   if(selected >= 0 && selected < 256) {

--- a/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
+++ b/bsnes/ui-qt/debugger/ppu/image-grid-widget.cpp
@@ -85,7 +85,7 @@ void ImageGridWidget::setSelected(const QPoint& cell) {
 }
 
 void ImageGridWidget::scrollToCell(const QPoint& cell) {
-  QPoint p = matrix().map(cell * int(gridSize));
+  QPoint p = transform().map(cell * int(gridSize));
 
   horizontalScrollBar()->setValue(p.x());
   verticalScrollBar()->setValue(p.y());

--- a/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-data-model.cpp
@@ -138,7 +138,7 @@ QModelIndex OamDataModel::parent(const QModelIndex & index) const {
 }
 
 Qt::ItemFlags OamDataModel::flags(const QModelIndex & index) const {
-  if(isIndexValid(index) == false) return 0;
+  if(isIndexValid(index) == false) return {};
 
   if(index.column() == ID) {
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;

--- a/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/oam-viewer.cpp
@@ -53,7 +53,7 @@ OamViewer::OamViewer() {
   treeView->setContextMenuPolicy(Qt::ActionsContextMenu);
   layout->addWidget(treeView);
 
-  unsigned dw = treeView->fontMetrics().width('0');
+  unsigned dw = treeView->fontMetrics().horizontalAdvance('0');
   treeView->setColumnWidth(0, dw * 6);
   treeView->setColumnWidth(1, dw * 8);
   treeView->setColumnWidth(2, dw * 6);
@@ -129,7 +129,7 @@ OamViewer::OamViewer() {
   firstSprite = new QLineEdit;
   firstSprite->setReadOnly(true);
   firstSprite->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-  firstSprite->setMinimumWidth(5 * firstSprite->fontMetrics().width('0'));
+  firstSprite->setMinimumWidth(5 * firstSprite->fontMetrics().horizontalAdvance('0'));
   sidebarLayout->addRow("First Sprite:", firstSprite);
 
 
@@ -299,7 +299,7 @@ void OamCanvas::paintEvent(QPaintEvent*e) {
 
   if(!pixmap.isNull()) {
     QPainter painter(this);
-    painter.setRenderHints(0);
+    painter.setRenderHints({});
 
     unsigned x = (width() - pixmapScale * pixmap.width()) / 2;
     unsigned y = (height() - pixmapScale * pixmap.height()) / 2;

--- a/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
+++ b/bsnes/ui-qt/debugger/ppu/tile-viewer.cpp
@@ -82,7 +82,7 @@ TileViewer::TileViewer() {
 
   address = new QLineEdit;
   address->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-  address->setMinimumWidth(7 * address->fontMetrics().width('0'));
+  address->setMinimumWidth(7 * address->fontMetrics().horizontalAdvance('0'));
   addressLayout->addWidget(address, 1);
 
   nextAddressButton = new QToolButton;
@@ -148,7 +148,7 @@ TileViewer::TileViewer() {
 
     vramBaseAddress[i] = new QLineEdit;
     vramBaseAddress[i]->setReadOnly(true);
-    vramBaseAddress[i]->setFixedWidth(9 * vramBaseAddress[i]->fontMetrics().width('0'));
+    vramBaseAddress[i]->setFixedWidth(9 * vramBaseAddress[i]->fontMetrics().horizontalAdvance('0'));
     vramBaseLayout->addWidget(vramBaseAddress[i], i, 2);
 
     vramBaseButton[i] = new QToolButton;

--- a/bsnes/ui-qt/debugger/registeredit.cpp
+++ b/bsnes/ui-qt/debugger/registeredit.cpp
@@ -10,7 +10,7 @@ RegisterEditSGB *registerEditSGB;
 	edit_##name = new QLineEdit(this); \
 	edit_##name->setFont(QFont(Style::Monospace)); \
 	edit_##name->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum); \
-	edit_##name->setFixedWidth((digits + 1) * edit_##name->fontMetrics().width('0')); \
+	edit_##name->setFixedWidth((digits + 1) * edit_##name->fontMetrics().horizontalAdvance('0')); \
 	edit_##name->setInputMask(QString("H").repeated(digits)); \
 	edit_##name->setMaxLength(digits); \
 	connect(edit_##name, SIGNAL(textEdited(QString)), this, SLOT(commit())); \
@@ -186,7 +186,7 @@ void RegisterEditSFX::setupUI() {
 		edit_r[reg] = new QLineEdit(this);
 		edit_r[reg]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
 		edit_r[reg]->setFont(QFont(Style::Monospace));
-		edit_r[reg]->setFixedWidth((4 + 1) * edit_r[reg]->fontMetrics().width('0'));
+		edit_r[reg]->setFixedWidth((4 + 1) * edit_r[reg]->fontMetrics().horizontalAdvance('0'));
 		edit_r[reg]->setInputMask("HHHH");
 		edit_r[reg]->setMaxLength(4);
 		connect(edit_r[reg], SIGNAL(textEdited(QString)), this, SLOT(commit()));

--- a/bsnes/ui-qt/debugger/tools/breakpoint.cpp
+++ b/bsnes/ui-qt/debugger/tools/breakpoint.cpp
@@ -393,7 +393,7 @@ void BreakpointEditor::add() {
 
 void BreakpointEditor::remove() {
   QModelIndexList selected = table->selectionModel()->selectedRows();
-  qSort(selected);
+  std::sort(selected.begin(), selected.end());
   if (selected.count() > 0) {
     model->removeRows(selected[0].row(), selected.count());
   }

--- a/bsnes/ui-qt/debugger/tools/qhexedit2/qhexedit.cpp
+++ b/bsnes/ui-qt/debugger/tools/qhexedit2/qhexedit.cpp
@@ -344,7 +344,7 @@ QString QHexEdit::selectionToReadableString()
 void QHexEdit::setFont(const QFont &font)
 {
     QWidget::setFont(font);
-    _pxCharWidth = fontMetrics().width(QLatin1Char('2'));
+    _pxCharWidth = fontMetrics().horizontalAdvance(QLatin1Char('2'));
     _pxCharHeight = fontMetrics().height() + 1;
     _pxGapAdr = _pxCharWidth / 2;
     _pxGapAdrHex = _pxCharWidth;

--- a/bsnes/ui-qt/settings/audio.cpp
+++ b/bsnes/ui-qt/settings/audio.cpp
@@ -44,7 +44,7 @@ AudioSettingsWindow::AudioSettingsWindow() {
 
   volumeValue = new QLabel;
   volumeValue->setAlignment(Qt::AlignHCenter);
-  volumeValue->setMinimumWidth(volumeValue->fontMetrics().width("262144hz"));
+  volumeValue->setMinimumWidth(volumeValue->fontMetrics().horizontalAdvance("262144hz"));
   sliders->addWidget(volumeValue, 0, 1);
 
   volume = new QSlider(Qt::Horizontal);

--- a/bsnes/ui-qt/settings/video.cpp
+++ b/bsnes/ui-qt/settings/video.cpp
@@ -25,7 +25,7 @@ VideoSettingsWindow::VideoSettingsWindow() {
 
   contrastValue = new QLabel;
   contrastValue->setAlignment(Qt::AlignHCenter);
-  contrastValue->setMinimumWidth(contrastValue->fontMetrics().width("+100%"));
+  contrastValue->setMinimumWidth(contrastValue->fontMetrics().horizontalAdvance("+100%"));
   colorLayout->addWidget(contrastValue, 0, 1);
 
   contrastSlider = new QSlider(Qt::Horizontal);
@@ -88,7 +88,7 @@ VideoSettingsWindow::VideoSettingsWindow() {
 
   cropLeftValue = new QLabel;
   cropLeftValue->setAlignment(Qt::AlignHCenter);
-  cropLeftValue->setMinimumWidth(cropLeftValue->fontMetrics().width("+100%"));
+  cropLeftValue->setMinimumWidth(cropLeftValue->fontMetrics().horizontalAdvance("+100%"));
   cropLayout->addWidget(cropLeftValue, 0, 1);
 
   cropLeftSlider = new QSlider(Qt::Horizontal);

--- a/bsnes/ui-qt/tools/cheateditor.cpp
+++ b/bsnes/ui-qt/tools/cheateditor.cpp
@@ -14,7 +14,7 @@ CheatEditorWindow::CheatEditorWindow() {
   list = new QTreeWidget;
   list->setColumnCount(3);
   list->setHeaderLabels(QStringList() << "Slot" << "Code" << "Description");
-  list->setColumnWidth(1, list->fontMetrics().width("  89AB-CDEF+...  "));
+  list->setColumnWidth(1, list->fontMetrics().horizontalAdvance("  89AB-CDEF+...  "));
   list->setAllColumnsShowFocus(true);
   list->sortByColumn(0, Qt::AscendingOrder);
   list->setRootIsDecorated(false);

--- a/snesfilter/ntsc/ntsc.cpp
+++ b/snesfilter/ntsc/ntsc.cpp
@@ -60,7 +60,7 @@ QWidget* NTSCFilter::settings() {
     gridLayout->addWidget(hueLabel, 1, 0);
 
     hueValue = new QLabel;
-    hueValue->setMinimumWidth(hueValue->fontMetrics().width("-100.0"));
+    hueValue->setMinimumWidth(hueValue->fontMetrics().horizontalAdvance("-100.0"));
     hueValue->setAlignment(Qt::AlignHCenter);
     gridLayout->addWidget(hueValue, 1, 1);
 


### PR DESCRIPTION
`width` is deprecated and should be replaced by `horizontalAdvance` as well as `qsort` is deprecated and `std::sort` should be used.