### PR TITLE
Add toggle to log breakpoints without actually breaking

### DIFF
--- a/bsnes/snes/debugger/debugger.cpp
+++ b/bsnes/snes/debugger/debugger.cpp
@@ -204,6 +204,7 @@ Debugger::Debugger() {
   bus_access = false;
   break_on_wdm = false;
   break_on_brk = false;
+  log_without_break = false;
 
   step_type = StepType::None;
 }

--- a/bsnes/snes/debugger/debugger.hpp
+++ b/bsnes/snes/debugger/debugger.hpp
@@ -51,6 +51,7 @@ public:
   bool bus_access;
   bool break_on_wdm;
   bool break_on_brk;
+  bool log_without_break;
 
   enum class StepType : unsigned {
     None, StepToNMI, StepToIRQ, StepToVBlank, StepToHBlank, StepInto, StepOver, StepOut

--- a/bsnes/ui-qt/application/application.cpp
+++ b/bsnes/ui-qt/application/application.cpp
@@ -205,7 +205,7 @@ void Application::run() {
     SNES::system.run();
     #if defined(DEBUGGER)
     if(SNES::debugger.break_event != SNES::Debugger::BreakEvent::None) {
-      debug = true;
+      debug = !SNES::debugger.log_without_break;
       debugrun = false;
       debugger->synchronize();
       debugger->event();

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -686,8 +686,10 @@ void Debugger::event() {
   
   audio.clear();
   autoUpdate();
-  show();
-  activateWindow();
+  if(!SNES::debugger.log_without_break) {
+    show();
+    activateWindow();
+  }
 }
 
 // update "auto refresh" tool windows

--- a/bsnes/ui-qt/debugger/tools/breakpoint.cpp
+++ b/bsnes/ui-qt/debugger/tools/breakpoint.cpp
@@ -390,6 +390,11 @@ BreakpointEditor::BreakpointEditor() {
   breakOnBRK->setChecked(SNES::debugger.break_on_brk);
   connect(breakOnBRK, SIGNAL(toggled(bool)), this, SLOT(toggle()));
   layout->addWidget(breakOnBRK);
+
+  logWithoutBreak = new QCheckBox("Log breakpoints without breaking");
+  logWithoutBreak->setChecked(SNES::debugger.log_without_break);
+  connect(logWithoutBreak, SIGNAL(toggled(bool)), this, SLOT(toggle()));
+  layout->addWidget(logWithoutBreak);
 }
 
 void BreakpointEditor::add() {
@@ -407,6 +412,7 @@ void BreakpointEditor::remove() {
 void BreakpointEditor::toggle() {
   SNES::debugger.break_on_brk = breakOnBRK->isChecked();
   SNES::debugger.break_on_wdm = breakOnWDM->isChecked();
+  SNES::debugger.log_without_break = logWithoutBreak->isChecked();
 }
 
 void BreakpointEditor::clear() {

--- a/bsnes/ui-qt/debugger/tools/breakpoint.moc.hpp
+++ b/bsnes/ui-qt/debugger/tools/breakpoint.moc.hpp
@@ -74,6 +74,7 @@ public:
   QPushButton *btnRemove;
   QCheckBox *breakOnWDM;
   QCheckBox *breakOnBRK;
+  QCheckBox *logWithoutBreak;
 
   static const QStringList sources;
   


### PR DESCRIPTION
This adds a toggle in the breakpoint editor window to allow the game to continue running uninterrupted when a breakpoint is hit.  This is useful in cases where a breakpoint gets hit repeatedly before actually reaching the one you're looking for, especially true with register writes and such.  I'm not sure if it's quite ready to be merged in its current state, ideally I'd like to actually log to a file, like the tracelog (though it should probably be a separate file and not overwrite the tracelog), but I haven't figured that out yet, so for now it's just outputting to the Debugger window like it currently does.