### PR TITLE
Show S-SMP timer-enabled status in debugger's Properties dialog

### DIFF
--- a/bsnes/snes/smp/debugger/debugger.cpp
+++ b/bsnes/snes/smp/debugger/debugger.cpp
@@ -95,6 +95,9 @@ bool SMPDebugger::property(unsigned id, string &name, string &value) {
   //$00f1
   item("$00f1", "");
   item("IPLROM Enable", status.iplrom_enabled);
+  item("Timer 0 Enable", t0.enabled);
+  item("Timer 1 Enable", t1.enabled);
+  item("Timer 2 Enable", t2.enabled);
 
   //$00f2
   item("$00f2-$00f3", "");


### PR DESCRIPTION
Fixes the secondary issue I mentioned in #282, but not the primary bug report.

Tested to work on Linux (Arch), and provides useful information when analyzing the sound engines found in SPC files.