### PR TITLE
Fix issue #288 - retina display opengl

### DIFF
--- a/bsnes/ruby/video/qtopengl.cpp
+++ b/bsnes/ruby/video/qtopengl.cpp
@@ -52,6 +52,8 @@ public:
     void paintGL() {
       unsigned outputWidth  = width();
       unsigned outputHeight = height();
+      outputWidth *= QApplication::desktop()->devicePixelRatio();
+      outputHeight *= QApplication::desktop()->devicePixelRatio();
 
       glMatrixMode(GL_PROJECTION);
       glLoadIdentity();

--- a/bsnes/ruby/video/qtopengl.cpp
+++ b/bsnes/ruby/video/qtopengl.cpp
@@ -50,10 +50,15 @@ public:
     }
 
     void paintGL() {
-      unsigned outputWidth  = width();
-      unsigned outputHeight = height();
-      outputWidth *= QApplication::desktop()->devicePixelRatio();
-      outputHeight *= QApplication::desktop()->devicePixelRatio();
+ #if QT_VERSION >= 0x050600 
+      qreal pixelRatio = devicePixelRatioF();
+ #elif QT_VERSION >= 0x050000 
+      int pixelRatio = devicePixelRatio();
+ #else 
+      int pixelRatio = 1; 
+ #endif 
+      unsigned outputWidth  = width() * pixelRatio;
+      unsigned outputHeight = height() * pixelRatio;
 
       glMatrixMode(GL_PROJECTION);
       glLoadIdentity();


### PR DESCRIPTION
ruby: scale opengl output by devicePixelRatio; fixes 1/4 surface bug on high-dpi displays such as retina
Fixes issue #288 