### PR TITLE
dos: fixed floppy memory bug, added xml mapping

### DIFF
--- a/bsnes/snes/cartridge/cartridge.cpp
+++ b/bsnes/snes/cartridge/cartridge.cpp
@@ -57,6 +57,8 @@ void Cartridge::load(Mode cartridge_mode, const lstring &xml_list) {
   has_st0018     = false;
   has_msu1       = false;
   has_serial     = false;
+  has_dos        = false;
+  dos_mapped     = false;
 
   parse_xml(xml_list);
 //print(xml_list[0], "\n\n");

--- a/bsnes/snes/cartridge/cartridge.hpp
+++ b/bsnes/snes/cartridge/cartridge.hpp
@@ -56,6 +56,9 @@ public:
   readonly<bool> has_st0018;
   readonly<bool> has_msu1;
   readonly<bool> has_serial;
+  readonly<bool> has_dos;
+
+  readonly<bool> dos_mapped;
 
   struct Mapping {
     Memory *memory;
@@ -110,6 +113,7 @@ private:
   void xml_parse_setarisc(xml_element&);
   void xml_parse_msu1(xml_element&);
   void xml_parse_serial(xml_element&);
+  void xml_parse_dos(xml_element&);
 
   void xml_parse_address(Mapping&, const string&);
   void xml_parse_mode(Mapping&, const string&);

--- a/bsnes/snes/chip/dos/dos.hpp
+++ b/bsnes/snes/chip/dos/dos.hpp
@@ -1,6 +1,9 @@
 class DOSSerial {
 public:
+  void init();
   void reset();
+  void power();
+  void unload();
 
   // CPU interface ($5f0x)
   uint8 read(uint3 addr);
@@ -43,7 +46,10 @@ private:
 
 class DOSFloppy {
 public:
+  void init();
   void reset();
+  void power();
+  void unload();
 
   // CPU interface ($5f2x)
   uint8 read(bool addr);
@@ -88,6 +94,7 @@ public:
   void enable();
   void power();
   void reset();
+  void unload();
 
   void serialize(serializer&);
 

--- a/bsnes/snes/chip/dos/dos_base.cpp
+++ b/bsnes/snes/chip/dos/dos_base.cpp
@@ -9,12 +9,11 @@ DOS::~DOS() {
 }
 
 void DOS::init() {
-  reset();
+  serial.init();
+  floppy.init();
 }
 
 void DOS::enable() {
-  bus.map(Bus::MapMode::Direct, 0x00, 0x3f, 0x5f00, 0x5fff, *this);
-  bus.map(Bus::MapMode::Direct, 0x80, 0xbf, 0x5f00, 0x5fff, *this);
 
   // terrible hack to patch the NMI and IRQ vectors in the standard
   // SFX-DOS ROM, since they normally have bogus addresses for some reason
@@ -33,12 +32,18 @@ void DOS::enable() {
 }
 
 void DOS::power() {
-  reset();
+  serial.power();
+  floppy.power();
 }
 
 void DOS::reset() {
   serial.reset();
   floppy.reset();
+}
+
+void DOS::unload() {
+  serial.unload();
+  floppy.unload();
 }
 
 uint8 DOS::read(unsigned addr) {

--- a/bsnes/snes/chip/dos/dos_serial.cpp
+++ b/bsnes/snes/chip/dos/dos_serial.cpp
@@ -7,11 +7,24 @@ DOSSerial::DOSSerial() {
 DOSSerial::~DOSSerial() {
 }
 
+
+void DOSSerial::init() {
+  reset();
+}
+
 void DOSSerial::reset() {
   reset(0);
   reset(1);
   
   irq_enable = false;
+}
+
+void DOSSerial::power() {
+  reset();
+}
+
+void DOSSerial::unload() {
+
 }
 
 void DOSSerial::reset(bool channel) {

--- a/bsnes/snes/chip/dos/upd765.h
+++ b/bsnes/snes/chip/dos/upd765.h
@@ -161,6 +161,7 @@ extern "C" {
 /* auxiliary command codes */
 #define UPD72069_AUX_RESET                  ((1<<5)|(1<<4)|(1<<2)|(1<<1))
 #define UPD72069_AUX_SET_STANDBY            ((1<<5)|(1<<4)|(1<<2)|(1<<0))
+#define UPD72069_AUX_RESET_STANDBY          ((1<<5)|(1<<4)|(1<<2))
 #define UPD72069_AUX_START_CLOCK            ((1<<6)|(1<<2)|(1<<1)|(1<<0))
 #define UPD72069_AUX_INTERNAL_MODE_250      ((1<<3)|(1<<1)|(1<<0))
 #define UPD72069_AUX_INTERNAL_MODE_300      ((1<<7)|(1<<6)|(1<<3)|(1<<1)|(1<<0))
@@ -746,6 +747,7 @@ static void _upd765_write_aux(upd765_t* upd, uint8_t data) {
     switch (data) {
         case UPD72069_AUX_RESET: printf("UPD72069_AUX_RESET\n"); break;
         case UPD72069_AUX_SET_STANDBY: printf("UPD72069_AUX_SET_STANDBY\n"); break;
+        case UPD72069_AUX_RESET_STANDBY: printf("UPD72069_AUX_RESET_STANDBY\n"); break;
         case UPD72069_AUX_START_CLOCK: printf("UPD72069_AUX_START_CLOCK\n"); break;
         case UPD72069_AUX_INTERNAL_MODE_250: printf("UPD72069_AUX_INTERNAL_MODE_250\n"); break;
         case UPD72069_AUX_INTERNAL_MODE_300: printf("UPD72069_AUX_INTERNAL_MODE_300\n"); break;
@@ -764,6 +766,7 @@ static void _upd765_write_aux(upd765_t* upd, uint8_t data) {
         case UPD72069_AUX_START_CLOCK:
             break;
 
+        case UPD72069_AUX_RESET_STANDBY:
         case UPD72069_AUX_INTERNAL_MODE_250:
         case UPD72069_AUX_INTERNAL_MODE_300:
         case UPD72069_AUX_INTERNAL_MODE_500:

--- a/bsnes/snes/memory/memory.cpp
+++ b/bsnes/snes/memory/memory.cpp
@@ -142,6 +142,7 @@ bool Bus::load_cart() {
 }
 
 void Bus::unload_cart() {
+    dos.unload();
 }
 
 void Bus::map_reset() {


### PR DESCRIPTION
fixed bug where floppy data buffer from previous session would be saved to next session's floppy buffer when cartridge loaded.
added xml parsing option for remapping dos
added FDC_RESET_STANDBY debugging output, however standby and clock functionality are not implemented yet.
added debugging output detecting whether a floppy disk image already exists for a current rom, and creates a new disk only if one doesn't exist.