### PR TITLE
Allow for dumping an SPC file immediately via config option

### DIFF
--- a/bsnes/snes/config/config.cpp
+++ b/bsnes/snes/config/config.cpp
@@ -12,6 +12,7 @@ Configuration::Configuration() {
   vram_size        = 0; // 64 kb
   region           = System::Region::Autodetect;
   random           = true;
+  spc_save_policy  = SNES::SMP::SPCSavePolicy::OnNextNote;
 
   cpu.version         = 2;
   cpu.ntsc_frequency  = 21477272;  //315 / 88 * 6000000

--- a/bsnes/snes/config/config.hpp
+++ b/bsnes/snes/config/config.hpp
@@ -5,6 +5,7 @@ struct Configuration {
   unsigned vram_size;
   System::Region region;
   bool random;
+  SMP::SPCSavePolicy spc_save_policy;
 
   struct CPU {
     unsigned version;

--- a/bsnes/snes/smp/smp.cpp
+++ b/bsnes/snes/smp/smp.cpp
@@ -171,6 +171,9 @@ void SMP::load_dump(uint8 *dump, uint16_t pc, uint8_t r[4], uint8_t p) {
 void SMP::save_spc_dump(string path) {
   dump_spc = true;
   spc_path = path;
+  if(config().spc_save_policy == SPCSavePolicy::Immediately) {
+    save_spc_dump();
+  }
 }
 
 void SMP::save_spc_dump() {

--- a/bsnes/snes/smp/smp.hpp
+++ b/bsnes/snes/smp/smp.hpp
@@ -1,6 +1,7 @@
 class SMP : public Processor, public SMPcore, public MMIO {
 public:
   enum : bool { Threaded = true };
+  enum class SPCSavePolicy : unsigned { OnNextNote = 0, Immediately = 1 };
   alwaysinline void step(unsigned clocks);
   alwaysinline void synchronize_cpu();
   alwaysinline void synchronize_dsp();

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -17,6 +17,7 @@ Configuration::Configuration() {
   attach((unsigned&)(snes_config.expansion_port   = SNES::System::ExpansionPortDevice::BSX), "snes.expansionPort");
   attach((unsigned&)(snes_config.vram_size        = 0), "snes.vramSize");
   attach((unsigned&)(snes_config.region           = SNES::System::Region::Autodetect), "snes.region");
+  attach((unsigned&)(snes_config.spc_save_policy  = SNES::SMP::SPCSavePolicy::OnNextNote), "snes.SPCSavePolicy");
 
   attach(snes_config.random = true, "snes.random", "Randomize some system state on powerup");
 

--- a/bsnes/ui-qt/settings/advanced.cpp
+++ b/bsnes/ui-qt/settings/advanced.cpp
@@ -143,6 +143,26 @@ AdvancedSettingsWindow::AdvancedSettingsWindow() {
   useCommonDialogs = new QCheckBox("Use native OS file dialogs");
   layout->addWidget(useCommonDialogs);
 
+  saveSPCTitle = new QLabel("Save SPC file:");
+  layout->addWidget(saveSPCTitle);
+
+  saveSPCLayout = new QHBoxLayout;
+  saveSPCLayout->setSpacing(Style::WidgetSpacing);
+  layout->addLayout(saveSPCLayout);
+  layout->addSpacing(Style::WidgetSpacing);
+
+  saveSPCButtonGroup = new QButtonGroup(this);
+
+  saveSPCOnNextNote = new QRadioButton("At start of next note");
+  saveSPCOnNextNote->setToolTip("Typical use-case");
+  saveSPCButtonGroup->addButton(saveSPCOnNextNote);
+  saveSPCLayout->addWidget(saveSPCOnNextNote);
+
+  saveSPCImmediately = new QRadioButton("Immediately");
+  saveSPCImmediately->setToolTip("Useful for debugging");
+  saveSPCButtonGroup->addButton(saveSPCImmediately);
+  saveSPCLayout->addWidget(saveSPCImmediately);
+
   initializeUi();
 
   connect(videoDriver, SIGNAL(currentIndexChanged(int)), this, SLOT(videoDriverChange(int)));
@@ -160,6 +180,8 @@ AdvancedSettingsWindow::AdvancedSettingsWindow() {
   connect(rewindEnable, SIGNAL(stateChanged(int)), this, SLOT(toggleRewindEnable()));
   connect(allowInvalidInput, SIGNAL(stateChanged(int)), this, SLOT(toggleAllowInvalidInput()));
   connect(useCommonDialogs, SIGNAL(stateChanged(int)), this, SLOT(toggleUseCommonDialogs()));
+  connect(saveSPCOnNextNote, SIGNAL(pressed()), this, SLOT(setSaveSPCOnNextNote()));
+  connect(saveSPCImmediately, SIGNAL(pressed()), this, SLOT(setSaveSPCImmediately()));
 }
 
 void AdvancedSettingsWindow::initializeUi() {
@@ -210,6 +232,9 @@ void AdvancedSettingsWindow::initializeUi() {
   rewindEnable->setChecked(config().system.rewindEnabled);
   allowInvalidInput->setChecked(config().input.allowInvalidInput);
   useCommonDialogs->setChecked(config().diskBrowser.useCommonDialogs);
+  
+  saveSPCOnNextNote->setChecked (SNES::config().spc_save_policy == SNES::SMP::SPCSavePolicy::OnNextNote);
+  saveSPCImmediately->setChecked(SNES::config().spc_save_policy == SNES::SMP::SPCSavePolicy::Immediately);
 }
 
 void AdvancedSettingsWindow::videoDriverChange(int index) {
@@ -255,3 +280,6 @@ void AdvancedSettingsWindow::toggleAllowInvalidInput() {
 void AdvancedSettingsWindow::toggleUseCommonDialogs() {
   config().diskBrowser.useCommonDialogs = useCommonDialogs->isChecked();
 }
+
+void AdvancedSettingsWindow::setSaveSPCOnNextNote()  { SNES::config().spc_save_policy = SNES::SMP::SPCSavePolicy::OnNextNote; }
+void AdvancedSettingsWindow::setSaveSPCImmediately() { SNES::config().spc_save_policy = SNES::SMP::SPCSavePolicy::Immediately; }

--- a/bsnes/ui-qt/settings/advanced.moc.hpp
+++ b/bsnes/ui-qt/settings/advanced.moc.hpp
@@ -46,6 +46,12 @@ public:
   QCheckBox *rewindEnable;
   QCheckBox *allowInvalidInput;
   QCheckBox *useCommonDialogs;
+  
+  QLabel *saveSPCTitle;
+  QHBoxLayout *saveSPCLayout;
+  QButtonGroup *saveSPCButtonGroup;
+  QRadioButton *saveSPCOnNextNote;
+  QRadioButton *saveSPCImmediately;
 
   void initializeUi();
   AdvancedSettingsWindow();
@@ -69,6 +75,8 @@ public slots:
   void toggleRewindEnable();
   void toggleAllowInvalidInput();
   void toggleUseCommonDialogs();
+  void setSaveSPCOnNextNote();
+  void setSaveSPCImmediately();
 };
 
 extern AdvancedSettingsWindow *advancedSettingsWindow;


### PR DESCRIPTION
Hello,
This PR adds a new configuration option for dumping an SPC file immediately when the button is pressed, as opposed to dumping it on the next note-on event. The current behaviour of "dump on next note" remains the default.
Fixes #263 .
Thanks,
Cooper