### PR TITLE
fix crashes on little-endian powerpc

### DIFF
--- a/bsnes/libco/libco.c
+++ b/bsnes/libco/libco.c
@@ -18,7 +18,7 @@
     #endif
   #elif defined(__arm__)
     #include "arm.c"
-  #elif defined(_ARCH_PPC)
+  #elif defined(_ARCH_PPC) && !defined(__LITTLE_ENDIAN__)
     #include "ppc.c"
   #elif defined(_WIN32)
     #include "fiber.c"

--- a/bsnes/snes/alt/dsp/blargg_endian.h
+++ b/bsnes/snes/alt/dsp/blargg_endian.h
@@ -37,7 +37,7 @@
 #endif
 
 #if defined (MSB_FIRST)     || defined (__BIG_ENDIAN__) || defined (WORDS_BIGENDIAN) || \
-	defined (__sparc__)     ||  BLARGG_CPU_POWERPC || \
+	defined (__sparc__) || \
 	(defined (BIG_ENDIAN) && BIG_ENDIAN+0 != 4321)
 	#define BLARGG_BIG_ENDIAN 1
 #elif !defined (__mips__)

--- a/common/nall/detect.hpp
+++ b/common/nall/detect.hpp
@@ -21,7 +21,7 @@
 
 /* Endian detection */
 
-#if defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64)
+#if defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(__LITTLE_ENDIAN__)
   #define ARCH_LSB
 #elif defined(__powerpc__) || defined(_M_PPC) || defined(__BIG_ENDIAN__)
   #define ARCH_MSB


### PR DESCRIPTION
(modern POWER ISA is generally used in ppc64le configuration)