### PR TITLE
Fix D-pad inputs on macOS

### DIFF
--- a/bsnes/ruby/input/macos.cpp
+++ b/bsnes/ruby/input/macos.cpp
@@ -351,8 +351,11 @@ public:
 
       // Type: Misc - Usage: Hat switch
       if (usage == kHIDUsage_GD_Hatswitch) {
-        int range = (int)(IOHIDElementGetLogicalMax(element_ref) - IOHIDElementGetLogicalMin(element_ref));
+        int min = (int)IOHIDElementGetLogicalMin(element_ref);
+        int max = (int)IOHIDElementGetLogicalMax(element_ref);
+        int range = max - min;
         if (range == 3) value *= 2;
+        value -= min;
         switch (value) {
           case 0: table_buffer[joypad(device_slot).hat(0)] = Joypad::HatUp; break;
           case 1: table_buffer[joypad(device_slot).hat(0)] = Joypad::HatUp | Joypad::HatRight; break;
@@ -365,7 +368,7 @@ public:
           default:
             table_buffer[joypad(device_slot).hat(0)] = Joypad::HatCenter; break;
         }
-        //printf("hid_input_value_received - slot %d - hat %d %d\n", device_slot, value, cookie);
+        //printf("hid_input_value_received - slot %d - hat %d (range %d...%d) %d\n", device_slot, value, min, max, cookie);
       }
 
       // Type: Misc - Usage: D-Pad


### PR DESCRIPTION
Take into account that the minimum element of the range might not be zero. My Xbox One controller uses 1-based indexing and does not work without this change.

With this change, bsnes-plus works flawlessly on macOS (the compile command I used is `qtpath=(brew --prefix qt5) make -j24`). It is a bit tricky to compile on M1 because the version of Clang that ships with Xcode does not accept the `-march=native` flag. Upstream Clang 15 (which can be installed with `brew install llvm`) does work with this flag; however, the repository fails to compile due to a bug: llvm/llvm-project#59684

Once this bug is fixed, compiling with Clang 15 will be the best way to compile the repo on macOS. In the meantime, M1 users can replace `-march=native` with `-mcpu=apple-m1` in all the makefiles, and compile with Xcode clang.