### PR TITLE
Fix aeroplane mode turning on at regular intervals

### DIFF
--- a/bsnes/Makefile
+++ b/bsnes/Makefile
@@ -54,7 +54,8 @@ flags += -Wno-switch -Wno-parentheses
 
 # platform
 ifeq ($(platform),x)
-  link += -ldl -lX11 -lXext
+  flags += `pkg-config --cflags dbus-1`
+  link += -ldl -lX11 -lXext -ldbus-1
 else ifeq ($(platform),osx)
   osxbundle := ../bsnes+.app
   flags += -march=native -mmacosx-version-min=10.10

--- a/bsnes/ui-qt/application/application.cpp
+++ b/bsnes/ui-qt/application/application.cpp
@@ -64,11 +64,11 @@ void Application::locateFile(string &filename, bool createDataDirectory, bool cr
     if(createDataDirectory) mkdir(temp, 0755);  //ensure directory exists
     temp << "/" << filename;
   }
-  
+
   if(createFile && !QFile::exists(temp)) {
     QFile::copy(QString(":/") + filename(), temp);
   }
-  
+
   filename = temp;
 }
 
@@ -79,30 +79,30 @@ void Application::loadCartridge(const string &filename) {
       } else {
         cartridge.loadBsx(config().path.bsx, filename);
       }
-      
-    } else if(striend(filename, ".st")) { 
+
+    } else if(striend(filename, ".st")) {
       if(config().path.st == "") {
         loaderWindow->loadSufamiTurboCartridge("", filename, "");
       } else {
         cartridge.loadSufamiTurbo(config().path.st, filename, "");
       }
-      
+
     } else if(striend(filename, ".gb") || striend(filename, ".sgb") || striend(filename, ".gbc")) {
       if(config().path.sgb == "") {
         loaderWindow->loadSuperGameBoyCartridge("", filename);
       } else {
         cartridge.loadSuperGameBoy(config().path.sgb, filename);
       }
-      
+
     } else if(striend(filename, ".spc")) {
       cartridge.loadSpc(filename);
-      
+
     } else if(striend(filename, ".snsf") || striend(filename, ".minisnsf"))  {
       cartridge.loadSnsf(filename);
-      
+
     } else {
       cartridge.loadNormal(filename);
-      
+
     }
 }
 
@@ -111,19 +111,19 @@ void Application::reloadCartridge() {
   case SNES::Cartridge::Mode::Normal:
     loadCartridge(cartridge.baseName);
     break;
-  
+
   case SNES::Cartridge::Mode::BsxSlotted:
     cartridge.loadBsxSlotted(cartridge.baseName, cartridge.slotAName);
     break;
-  
+
   case SNES::Cartridge::Mode::Bsx:
     cartridge.loadBsx(cartridge.baseName, cartridge.slotAName);
     break;
-  
+
   case SNES::Cartridge::Mode::SufamiTurbo:
     cartridge.loadSufamiTurbo(cartridge.baseName, cartridge.slotAName, cartridge.slotBName);
     break;
-  
+
   case SNES::Cartridge::Mode::SuperGameBoy:
     cartridge.loadSuperGameBoy(cartridge.baseName, cartridge.slotAName);
     break;
@@ -185,7 +185,7 @@ void Application::run() {
     app->quit();
     return;
   }
-  
+
   utility.updateSystemState();
   mapper().poll();
 
@@ -233,12 +233,6 @@ void Application::run() {
     autosaveTime = 0;
     if(config().system.autoSaveMemory == true) cartridge.saveMemory();
   }
-
-  if(screensaverTime >= CLOCKS_PER_SEC * 30) {
-    //supress screen saver every 30 seconds so it will not trigger during gameplay
-    screensaverTime = 0;
-    supressScreenSaver();
-  }
 }
 
 Application::Application() : timer(0) {
@@ -253,8 +247,12 @@ Application::Application() : timer(0) {
   clockTime       = clock();
   autosaveTime    = 0;
   screensaverTime = 0;
-  
+
   loadType = SNES::Cartridge::Mode::Normal;
+
+  #ifdef PLATFORM_X
+  app->inhibitScreenSaver();
+  #endif
 }
 
 Application::~Application() {

--- a/bsnes/ui-qt/application/application.moc.hpp
+++ b/bsnes/ui-qt/application/application.moc.hpp
@@ -19,6 +19,9 @@ public:
     #if defined(PLATFORM_WIN)
     bool winEventFilter(MSG *msg, long *result);
     #endif
+    #if defined(PLATFORM_X)
+    void inhibitScreenSaver();
+    #endif
 
     App(int &argc, char **argv) : QApplication(argc, argv) {}
   } *app;

--- a/bsnes/ui-qt/main.cpp
+++ b/bsnes/ui-qt/main.cpp
@@ -5,7 +5,6 @@
   #include "platform/platform_x.cpp"
   const char Style::Monospace[64] = "monospace";
 #elif defined(PLATFORM_OSX)
-  #include "platform/platform_osx.cpp"
   const char Style::Monospace[64] = "Courier New";
 #elif defined(PLATFORM_WIN)
   #include "platform/platform_win.cpp"

--- a/bsnes/ui-qt/platform/platform_osx.cpp
+++ b/bsnes/ui-qt/platform/platform_osx.cpp
@@ -1,3 +1,0 @@
-void supressScreenSaver() {
-}
-

--- a/bsnes/ui-qt/platform/platform_win.cpp
+++ b/bsnes/ui-qt/platform/platform_win.cpp
@@ -4,7 +4,7 @@ bool Application::App::winEventFilter(MSG *msg, long *result) {
   //supress screen saver from activating during gameplay
   if(msg->message == WM_SYSCOMMAND) {
     WPARAM wParam = msg->wParam & 0xFFF0;
-  
+
     if(wParam == SC_SCREENSAVE || wParam == SC_MONITORPOWER) {
       *result = 0;
       return true;
@@ -18,8 +18,3 @@ bool Application::App::winEventFilter(MSG *msg, long *result) {
 
   return false;
 }
-
-void supressScreenSaver() {
-  //handled by event filter above
-}
-

--- a/bsnes/ui-qt/platform/platform_x.cpp
+++ b/bsnes/ui-qt/platform/platform_x.cpp
@@ -28,6 +28,7 @@ void Application::App::inhibitScreenSaver() {
   if (!dbus_message_append_args(message, DBUS_TYPE_STRING, &app,
                                 DBUS_TYPE_STRING, &reason, DBUS_TYPE_INVALID)) {
     dbus_connection_unref(connection);
+    dbus_message_unref(message);
     fputs("Failed to append arguments to DBus call\n", stderr);
     return;
   }

--- a/bsnes/ui-qt/platform/platform_x.cpp
+++ b/bsnes/ui-qt/platform/platform_x.cpp
@@ -1,33 +1,44 @@
 #define None XNone
 #define Window XWindow
-#include <X11/Xlib.h>
+#include <dbus/dbus.h>
 #undef None
 #undef Window
 
-struct LibXtst : public library {
-  function<int (Display*, unsigned int, Bool, unsigned long)> XTestFakeKeyEvent;
-
-  LibXtst() {
-    if(open("Xtst")) {
-      XTestFakeKeyEvent = sym("XTestFakeKeyEvent");
-    }
-  }
-} libXtst;
-
-void supressScreenSaver() {
-  if(!libXtst.XTestFakeKeyEvent) return;
-
-  //XSetScreenSaver(timeout = 0) does not work
-  //XResetScreenSaver() does not work
-  //XScreenSaverSuspend() does not work
-  //DPMSDisable() does not work
-  //XSendEvent(KeyPressMask) does not work
-  //use XTest extension to send fake keypress every ~20 seconds.
-  //keycode of 255 does not map to any actual key,
-  //but it will block screensaver and power management.
-  Display *display = XOpenDisplay(0);
-  libXtst.XTestFakeKeyEvent(display, 255, True,  0);
-  libXtst.XTestFakeKeyEvent(display, 255, False, 0);
-  XCloseDisplay(display);
+static void log(DBusError &error) {
+  fprintf(stderr, "DBus error: %s\n", error.name);
+  fprintf(stderr, "Message: %s\n", error.message);
 }
 
+void Application::App::inhibitScreenSaver() {
+  DBusError error;
+  dbus_error_init(&error);
+
+  DBusConnection *connection = dbus_bus_get(DBUS_BUS_SESSION, &error);
+  if (connection == nullptr) {
+    log(error);
+    return;
+  }
+
+  DBusMessage *message = dbus_message_new_method_call(
+      "org.freedesktop.ScreenSaver", "/org/freedesktop/ScreenSaver",
+      "org.freedesktop.ScreenSaver", "Inhibit");
+
+  const char *app = "org.bsnes.bsnes-plus";
+  const char *reason = tr("Playing a game").toLocal8Bit().data();
+  if (!dbus_message_append_args(message, DBUS_TYPE_STRING, &app,
+                                DBUS_TYPE_STRING, &reason, DBUS_TYPE_INVALID)) {
+    dbus_connection_unref(connection);
+    fputs("Failed to append arguments to DBus call\n", stderr);
+    return;
+  }
+
+  DBusMessage *reply = dbus_connection_send_with_reply_and_block(
+      connection, message, DBUS_TIMEOUT_USE_DEFAULT, &error);
+  dbus_connection_unref(connection);
+  dbus_message_unref(message);
+  if (reply == nullptr) {
+    log(error);
+    return;
+  }
+  dbus_message_unref(reply);
+}

--- a/bsnes/ui-qt/platform/platform_x.cpp
+++ b/bsnes/ui-qt/platform/platform_x.cpp
@@ -1,8 +1,4 @@
-#define None XNone
-#define Window XWindow
 #include <dbus/dbus.h>
-#undef None
-#undef Window
 
 static void log(DBusError &error) {
   fprintf(stderr, "DBus error: %s\n", error.name);
@@ -24,7 +20,7 @@ void Application::App::inhibitScreenSaver() {
       "org.freedesktop.ScreenSaver", "Inhibit");
 
   const char *app = "org.bsnes.bsnes-plus";
-  const char *reason = tr("Playing a game").toLocal8Bit().data();
+  const char *reason = "Playing a game";
   if (!dbus_message_append_args(message, DBUS_TYPE_STRING, &app,
                                 DBUS_TYPE_STRING, &reason, DBUS_TYPE_INVALID)) {
     dbus_connection_unref(connection);


### PR DESCRIPTION
Fixes #303 and #344. Instead of pressing key 255 which seems to trigger aeroplane mode at least in GNOME, it sends a DBus message.

supressScreenSaver isn't actually needed any more.

Partially based on
https://github.com/libretro/RetroArch/blob/master/gfx/common/dbus_common.c
(I only used it to work out how to use dbus_message_append_args so licensing isn't a concern)

P.S. it seems this repo doesn't have a license. I don't think this is allowed since bsnes is GPL licensed.