### PR TITLE
README: Update Linux Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Currently, OS X is not officially 100% supported. See [this fork](https://github
 As there is no ``configure`` step, make sure necessary Qt5/X11 packages are installed. On a Debian/Ubuntu system, it would require a command like:
 
 ```
-sudo apt install qt5-default qtbase5-dev-tools libxv-dev libsdl1.2-dev libao-dev libopenal-dev g++
+sudo apt install qtbase5-dev qtbase5-dev-tools libxv-dev libsdl1.2-dev libao-dev libopenal-dev g++
 ```
+
+(`qtbase5-dev` might be `qt5-default` on older distros)
 
 Afterwards, run ``make`` and if everything works out correctly you will find the output binary in the ``out/`` directory.
 


### PR DESCRIPTION
Package qt5-default is now qtbase5-dev on Debian 11+ and Ubuntu 20.04+.

Update Linux build doc, but still mention older package name for older distros.

Signed off by: Jamie Bainbridge <jamie.bainbridge@gmail.com>