### PR TITLE
Use correct symbols when writing comments to a WLA symbol file

### DIFF
--- a/bsnes/ui-qt/debugger/disassembler/symbols/adapters/wla_symbol_file.cpp
+++ b/bsnes/ui-qt/debugger/disassembler/symbols/adapters/wla_symbol_file.cpp
@@ -135,7 +135,7 @@ bool WlaSymbolFile::write(nall::file &f, SymbolMap *map) const {
   f.print("\n");
   f.print("[comments]\n");
   foreach(symbols, map->symbols) {
-    s = map->symbols[i].getComment();
+    s = symbols.getComment();
     if (!s.isInvalid()) {
       f.print(writeAddress(symbols.address), " ", s.name, "\n");
     }


### PR DESCRIPTION
There was a typo in the WLA adapter that would cause comments to not be written.